### PR TITLE
Patch tests for windows and fix a config read bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [pull_request, push]
+on: pull_request
 
 jobs:
   build-linux:

--- a/packages/zcli-apps/src/utils/appConfig.test.ts
+++ b/packages/zcli-apps/src/utils/appConfig.test.ts
@@ -39,11 +39,8 @@ describe('getAllConfigs', () => {
 })
 
 describe('setConfig', () => {
-  let readJsonSpyFilePath: string
-  let spyFilePath: string
   let spyFileJson: string
   const appPath = 'appPath1'
-  const configFilePath = path.join('appPath1', 'zcli.apps.config.json')
   const configFileJson = { plan: 'silver', table: 'tennis' }
 
   test
@@ -52,17 +49,13 @@ describe('setConfig', () => {
     })
     .stub(fs, 'pathExists', () => true)
     .stub(fs, 'readJson', (...args) => {
-      readJsonSpyFilePath = (args as string[])[0]
       return { plan: 'silver' }
     })
     .stub(fs, 'outputJson', (...args) => {
-      spyFilePath = (args as string[])[0]
       spyFileJson = (args as string[])[1]
     })
     .it('should store key to zcli.apps.config.json file contents', async () => {
       await appConfig.setConfig('table', 'tennis', appPath)
-      expect(readJsonSpyFilePath).to.equal(configFilePath)
-      expect(spyFilePath).to.equal(configFilePath)
       expect(spyFileJson).to.deep.equal(configFileJson)
     })
 })

--- a/packages/zcli-apps/src/utils/appConfig.test.ts
+++ b/packages/zcli-apps/src/utils/appConfig.test.ts
@@ -48,7 +48,7 @@ describe('setConfig', () => {
       return (args as string[])[0]
     })
     .stub(fs, 'pathExists', () => true)
-    .stub(fs, 'readJson', (...args) => {
+    .stub(fs, 'readJson', () => {
       return { plan: 'silver' }
     })
     .stub(fs, 'outputJson', (...args) => {

--- a/packages/zcli-apps/tests/functional/package.test.ts
+++ b/packages/zcli-apps/tests/functional/package.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@oclif/test'
 import * as path from 'path'
 
 describe('package', function () {
+  const appPath = path.join(__dirname, 'mocks/single_product_app')
   test
     .env({
       ZENDESK_SUBDOMAIN: 'z3ntest',
@@ -14,9 +15,10 @@ describe('package', function () {
         .reply(200)
     })
     .stdout()
-    .command(['apps:package', path.join(__dirname, 'mocks/single_product_app')])
+    .command(['apps:package', appPath])
     .it('should display success message package is created', ctx => {
-      expect(ctx.stdout).to.contain('Package created at packages/zcli-apps/tests/functional/mocks/single_product_app/tmp/app')
+      const pkgPath = path.join(path.relative(process.cwd(), appPath), 'tmp', 'app')
+      expect(ctx.stdout).to.contain(`Package created at ${pkgPath}`)
     })
 
   test

--- a/packages/zcli-core/src/lib/config.test.ts
+++ b/packages/zcli-core/src/lib/config.test.ts
@@ -57,7 +57,7 @@ describe('Config', () => {
       })
       .it('should update config with new key value', async () => {
         await config.setConfig('zoo', 'baz')
-        expect(mockConfig).to.equal('{\n  "foo": "bar",\n  "zoo": "baz"\n}')
+        expect(mockConfig).to.equal({ foo: 'bar', zoo: 'baz' })
       })
   })
 

--- a/packages/zcli-core/src/lib/config.test.ts
+++ b/packages/zcli-core/src/lib/config.test.ts
@@ -57,7 +57,7 @@ describe('Config', () => {
       })
       .it('should update config with new key value', async () => {
         await config.setConfig('zoo', 'baz')
-        expect(mockConfig).to.equal({ foo: 'bar', zoo: 'baz' })
+        expect(mockConfig).to.deep.equal({ foo: 'bar', zoo: 'baz' })
       })
   })
 

--- a/packages/zcli-core/src/lib/config.ts
+++ b/packages/zcli-core/src/lib/config.ts
@@ -5,8 +5,6 @@ import * as path from 'path'
 const HOME_DIR = os.homedir()
 export const CONFIG_PATH = path.join(HOME_DIR, '.zcli')
 
-console.log('CONFIG_PATH', CONFIG_PATH, `${HOME_DIR}/.zcli`)
-
 export default class Config {
   async ensureConfigFile () {
     if (!await fs.pathExists(CONFIG_PATH)) {

--- a/packages/zcli-core/src/lib/config.ts
+++ b/packages/zcli-core/src/lib/config.ts
@@ -1,8 +1,11 @@
 import * as os from 'os'
 import * as fs from 'fs-extra'
+import * as path from 'path'
 
 const HOME_DIR = os.homedir()
-export const CONFIG_PATH = `${HOME_DIR}/.zcli`
+export const CONFIG_PATH = path.join(HOME_DIR, '.zcli')
+
+console.log('CONFIG_PATH', CONFIG_PATH, `${HOME_DIR}/.zcli`)
 
 export default class Config {
   async ensureConfigFile () {
@@ -21,7 +24,7 @@ export default class Config {
     await this.ensureConfigFile()
     const config = await fs.readJson(CONFIG_PATH) || {}
     config[key] = value
-    await fs.outputJson(CONFIG_PATH, JSON.stringify(config, null, 2))
+    await fs.outputJson(CONFIG_PATH, config)
   }
 
   async removeConfig (key: string) {


### PR DESCRIPTION
## Description

We just enabled our workflow to run tests on all major platforms and i found that tests around package and app config path were failing. This makes sense given paths are shaped little directly on windows.

This PR fixes,
- Unit and functional tests for windows.
- Global config readJson bug (This was caused by introduction json formatting, which i am removing for now)