### PR TITLE
Update node-setup in actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: zendesk/checkout@v2
     - name: Use Node.js
-      uses: zendesk/setup-node@v1
+      uses: zendesk/setup-node@v2.1.2
       with:
         node-version: '12.x'
     - run: yarn install
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: zendesk/checkout@v2
     - name: Use Node.js
-      uses: zendesk/setup-node@v1
+      uses: zendesk/setup-node@v2.1.2
       with:
         node-version: '12.x'
     - run: yarn install
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: zendesk/checkout@v2
     - name: Use Node.js
-      uses: zendesk/setup-node@v1
+      uses: zendesk/setup-node@v2.1.2
       with:
         node-version: '12.x'
     - run: yarn install


### PR DESCRIPTION
## Description

Update node setup action so that all builds pass. At the moment node setup fails because Github has deprecated set-env and add-path commands
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
