### PR TITLE
feat(installationID): Fix Proxied API Calls from ZCLI

### DIFF
--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -52,7 +52,7 @@ export const getLocationIcons = (appPath: string, manifestLocations: Location): 
 }
 
 export const getInstallation = (appId: string, app: App, configFileContents: ZcliConfigFileContent, appSettings: ConfigParameters): Installation => {
-  const installationId = uuidV4()
+  const installationId = appId || uuidV4()
   return {
     app_id: appId,
     name: app.name,


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR defaults to using the appID for the Installation ID when making requests.

Alternately if the installation ID could be setup as an additional key/value in the  `zcli.apps.config.json`

## Detail

When an app makes requests via the `ZenDeskClient.request()` api it errors with `502` `Proxy error: Internal API error`. The 
`x-zendesk-app-installation-id` is set to a new UUIDv4 ID. In order for the request to proxy successfully this needs to be set to the appID which can be set in the `zcli.apps.config.json` with `{"app_id": 123123}`.

closes #22

## Checklist

- [ ] :guardsman: includes new unit and functional tests
