### PR TITLE
Make apps server settings prompt optional

### DIFF
--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -96,7 +96,7 @@ export const getAppSettings = async (manifest: Manifest, configParams: ConfigPar
     return result
   }, {})
 
-  const promptSettings = paramsNotInConfig ? await promptAndGetSettings(paramsNotInConfig, manifest.name) : {}
+  const promptSettings = paramsNotInConfig ? await promptAndGetSettings(paramsNotInConfig, manifest.name, false) : {}
   return { ...configSettings, ...promptSettings }
 }
 

--- a/packages/zcli-apps/src/utils/createApp.ts
+++ b/packages/zcli-apps/src/utils/createApp.ts
@@ -24,10 +24,11 @@ export const uploadAppPkg = async (pkgPath: string): Promise<any> => {
   return response.json()
 }
 
-export const promptAndGetSettings = async (params: ManifestParameter[], appName = 'app') => {
+export const promptAndGetSettings = async (params: ManifestParameter[], appName = 'app', valuesRequired = true) => {
   const settings: Dictionary<string> = {}
   for (const param of params) {
-    settings[param.name] = await cli.prompt(`Enter ${appName} setting.${param.name} value`, { type: param.secure ? 'hide' : 'normal' })
+    const value = await cli.prompt(`Enter ${appName} setting.${param.name} value`, { type: param.secure ? 'hide' : 'normal', required: valuesRequired })
+    if (value) settings[param.name] = value
   }
   return settings
 }


### PR DESCRIPTION
## Description

`zcli apps:server` will prompt for missing param options but it does not allow you to skip with Return key like zat.

## Detail

![zcli-apps-server-prompt-optional](https://user-images.githubusercontent.com/640416/106842167-9b191680-66f7-11eb-9038-66e5417afcdb.gif)

Fixes this issue https://github.com/zendesk/zcli/issues/16

## Checklist

- [x] :guardsman: includes new unit and functional tests
