### PR TITLE
Add installation id support for local testing

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -9,6 +9,7 @@ NOTE: You can set your apps config/settings in `zcli.apps.config.json` at the ro
 {
   "plan": "silver",
   "app_id": 123,
+  "installation_id": 12434234,
   "parameters": {
     "someToken": "fksjdhfb231435",
     "someSecret": 123

--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -52,7 +52,8 @@ export const getLocationIcons = (appPath: string, manifestLocations: Location): 
 }
 
 export const getInstallation = (appId: string, app: App, configFileContents: ZcliConfigFileContent, appSettings: ConfigParameters): Installation => {
-  const installationId = uuidV4()
+  const installationId = configFileContents.installation_id || uuidV4()
+
   return {
     app_id: appId,
     name: app.name,

--- a/packages/zcli-apps/src/types.ts
+++ b/packages/zcli-apps/src/types.ts
@@ -3,6 +3,7 @@ export interface ZcliConfigFileContent {
     zat_update_check?: string;
     plan?: string;
     app_id?: string;
+    installation_id?: string;
     parameters?: ConfigParameters;
 }
 


### PR DESCRIPTION
## Description

This does not work for ZCLI
https://developer.zendesk.com/apps/docs/developer-guide/using_sdk#testing-an-app-with-secure-settings-locally
https://github.com/zendesk/zcli/issues/22

This PR fixes above issue by adding installation id support for zcli apps server's app.json

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
