### PR TITLE
Fix api token basic auth token generation

### DIFF
--- a/packages/zcli-core/src/lib/auth.test.ts
+++ b/packages/zcli-core/src/lib/auth.test.ts
@@ -36,7 +36,7 @@ describe('Auth', () => {
       })
       .stub(auth, 'createBasicAuthToken', mockCreateBasicAuthToken)
       .it('should return basic token if ZENDESK_EMAIL and ZENDESK_API_TOKEN is set', async () => {
-        expect(await auth.getAuthorizationToken()).to.equal('Basic test@zendesk.com_token/test_api_token_base64')
+        expect(await auth.getAuthorizationToken()).to.equal('Basic test@zendesk.com/token_test_api_token_base64')
       })
 
     test
@@ -75,7 +75,7 @@ describe('Auth', () => {
       })
       .stub(auth, 'createBasicAuthToken', mockCreateBasicAuthToken)
       .it('should give precedence to ZENDESK_EMAIL and ZENDESK_API_TOKEN when ZENDESK_OAUTH_TOKEN is not defined', async () => {
-        expect(await auth.getAuthorizationToken()).to.equal('Basic test@zendesk.com_token/test_api_token_base64')
+        expect(await auth.getAuthorizationToken()).to.equal('Basic test@zendesk.com/token_test_api_token_base64')
       })
   })
 

--- a/packages/zcli-core/src/lib/auth.ts
+++ b/packages/zcli-core/src/lib/auth.ts
@@ -26,7 +26,7 @@ export default class Auth {
     if (ZENDESK_OAUTH_TOKEN) {
       return `Bearer ${ZENDESK_OAUTH_TOKEN}`
     } else if (ZENDESK_EMAIL && ZENDESK_API_TOKEN) {
-      return this.createBasicAuthToken(ZENDESK_EMAIL, `token/${ZENDESK_API_TOKEN}`)
+      return this.createBasicAuthToken(`${ZENDESK_EMAIL}/token`, ZENDESK_API_TOKEN)
     } else if (ZENDESK_EMAIL && ZENDESK_PASSWORD) {
       return this.createBasicAuthToken(ZENDESK_EMAIL, ZENDESK_PASSWORD)
     } else {

--- a/packages/zcli-core/src/lib/request.test.ts
+++ b/packages/zcli-core/src/lib/request.test.ts
@@ -14,7 +14,7 @@ describe('requestAPI', () => {
       api
         .get('/api/v2/me')
         .reply(function () {
-          expect(this.req.headers.authorization[0]).to.equal('Basic dGVzdEB6ZW5kZXNrLmNvbTp0b2tlbi8xMjM0NTY=')
+          expect(this.req.headers.authorization[0]).to.equal('Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY=')
           return [200]
         })
     })
@@ -34,7 +34,7 @@ describe('requestAPI', () => {
       api
         .get('/api/v2/me')
         .reply(function () {
-          expect(this.req.headers.authorization[0]).to.equal('Basic dGVzdEB6ZW5kZXNrLmNvbTp0b2tlbi8xMjM0NTY=')
+          expect(this.req.headers.authorization[0]).to.equal('Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY=')
           expect(this.req.headers.foo[0]).to.equal('bar')
           return [200]
         })


### PR DESCRIPTION
## Description

zcli unattended auth fails when using API token.

## Detail

Issue was caused due to adding a `/` after `token` instead of in front of it.  🤦 

## Manual QA

1. set your credentials
```
➜  export ZENDESK_SUBDOMAIN='z3ntest'
➜  export ZENDESK_PASSWORD='password'
➜  export ZENDESK_EMAIL='sasangi@zendesk.com'
```

2 `yarn dev apps:validate ./you-app`

3. your should not get 403

## Checklist

- [x] :guardsman: includes new unit and functional tests
