### PR TITLE
[update-documentation] Remove config option from apps:server doc

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -122,7 +122,6 @@ USAGE
 OPTIONS
   -h, --help       show CLI help
   --bind=bind      [default: localhost] Bind apps server to a specific host
-  --config=config  [default: zcli.apps.config.json] Configuration file for zcli::apps
   --logs           Tail logs
   --port=port      [default: 4567] Port for the http server to use
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
As we are no longer able to support `--config` option in `apps:server` while supporting multiple apps, this has been removed from the apps:server documentation.
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
