### PR TITLE
[VEG-600] Use new app_scaffolds monorepo for zcli apps:new command

### DIFF
--- a/packages/zcli-apps/package.json
+++ b/packages/zcli-apps/package.json
@@ -25,7 +25,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "form-data": "3.0.1",
-    "fs-extra": "9.1.0",
+    "fs-extra": "^10.0.0",
     "morgan": "1.10.0",
     "node-fetch": "^2.6.0",
     "rimraf": "3.0.2",

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -32,7 +32,7 @@ export default class New extends Command {
   unzippedScaffoldPath = path.join(process.cwd(), 'app_scaffolds-master')
   EMAIL_REGEX = /^.+@.+\..+$/
 
-  async downloadScaffold (url: string) {
+  async downloadScaffoldsRepo (url: string) {
     return new Promise((resolve, reject) => {
       const destination = fs.createWriteStream(this.zipScaffoldPath)
 
@@ -60,6 +60,9 @@ export default class New extends Command {
         path.join(process.cwd(), '/', `app_scaffolds-master-${flagScaffold}`),
         { overwrite: true, errorOnExist: true }, (err) => {
           if (err) {
+            if (err.code === 'ENOENT') {
+              reject(new Error(`Package ${flagScaffold} does not exist: ${err}`))
+            }
             reject(err)
           }
           resolve()
@@ -96,11 +99,11 @@ export default class New extends Command {
     const scaffoldUrl = 'https://codeload.github.com/zendesk/app_scaffolds/zip/master'
 
     try {
-      await this.downloadScaffold(scaffoldUrl)
+      await this.downloadScaffoldsRepo(scaffoldUrl)
       await this.extractSubfolderToTarget(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
-      throw new CLIError(chalk.red('Download of scaffold structure failed'))
+      throw new CLIError(chalk.red(`Download of scaffold structure failed with error: ${err}`))
     }
 
     fs.renameSync(path.join(process.cwd(), scaffoldDir), path.join(process.cwd(), directoryName))

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -1,4 +1,4 @@
-import { ManifestPath } from './../../types'
+import { FsExtraError, ManifestPath } from './../../types'
 import { Command, flags } from '@oclif/command'
 import { cleanDirectory } from '../../utils/fileUtils'
 import { getManifestFile, updateManifestFile } from '../../utils/manifest'
@@ -58,7 +58,7 @@ export default class New extends Command {
       fsExtra.copy(
         path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
         path.join(process.cwd(), '/', `app_scaffolds-master-${flagScaffold}`),
-        { overwrite: true, errorOnExist: true }, (err) => {
+        { overwrite: true, errorOnExist: true }, (err: FsExtraError) => {
           if (err) {
             if (err.code === 'ENOENT') {
               reject(new Error(`Package ${flagScaffold} does not exist: ${err}`))

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -84,7 +84,7 @@ export default class New extends Command {
     updateManifestFile(manifestPath[flagScaffold], manifest)
   }
 
-  async cleanAfterError() {
+  async cleanAfterError () {
     await cleanDirectory(this.unzippedScaffoldPath)
     try {
       await cleanDirectory(this.zipScaffoldPath)

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -103,6 +103,7 @@ export default class New extends Command {
       await this.extractScaffoldIfExists(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
+      await cleanDirectory(this.unzippedScaffoldPath)
       throw new CLIError(chalk.red(`Download of scaffold structure failed with error: ${err}`))
     }
 

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -53,7 +53,7 @@ export default class New extends Command {
     })
   }
 
-  async extractPackageIfExists (flagScaffold: string) {
+  async extractScaffoldIfExists (flagScaffold: string) {
     return new Promise((resolve, reject) => {
       fsExtra.copy(
         path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
@@ -61,7 +61,7 @@ export default class New extends Command {
         { overwrite: true, errorOnExist: true }, (err: FsExtraError) => {
           if (err) {
             if (err.code === 'ENOENT') {
-              reject(new Error(`Package ${flagScaffold} does not exist: ${err}`))
+              reject(new Error(`Scaffold ${flagScaffold} does not exist: ${err}`))
             }
             reject(err)
           }
@@ -100,7 +100,7 @@ export default class New extends Command {
 
     try {
       await this.downloadScaffoldsRepo(scaffoldUrl)
-      await this.extractPackageIfExists(flagScaffold)
+      await this.extractScaffoldIfExists(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
       throw new CLIError(chalk.red(`Download of scaffold structure failed with error: ${err}`))

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -52,6 +52,7 @@ export default class New extends Command {
         const zip = new AdmZip(this.zipScaffoldPath)
         const overwrite = false
         zip.extractAllToAsync(path.join(process.cwd()), overwrite, (err) => {
+          tryCleanUp(this.zipScaffoldPath)
           if (err) {
             reject(err)
           }
@@ -92,11 +93,6 @@ export default class New extends Command {
     updateManifestFile(manifestPath[flagScaffold], manifest)
   }
 
-  async cleanAfterError () {
-    await tryCleanUp(this.unzippedScaffoldPath)
-    await tryCleanUp(this.zipScaffoldPath)
-  }
-
   async run () {
     const { flags } = this.parse(New)
     const flagScaffold = flags.scaffold
@@ -116,13 +112,12 @@ export default class New extends Command {
       await this.extractScaffoldIfExists(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
-      await this.cleanAfterError()
+      await tryCleanUp(this.unzippedScaffoldPath)
       throw new CLIError(chalk.red(`Download of scaffold structure failed with error: ${err}`))
     }
 
     fs.renameSync(path.join(process.cwd(), scaffoldDir), path.join(process.cwd(), directoryName))
     this.modifyManifest(directoryName, appName, authorName, authorEmail, flagScaffold)
-    await tryCleanUp(this.zipScaffoldPath)
     console.log(chalk.green(`Successfully created new project ${directoryName}`))
   }
 }

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -53,7 +53,7 @@ export default class New extends Command {
     })
   }
 
-  async extractSubfolderToTarget (flagScaffold: string) {
+  async extractPackageIfExists (flagScaffold: string) {
     return new Promise((resolve, reject) => {
       fsExtra.copy(
         path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
@@ -100,7 +100,7 @@ export default class New extends Command {
 
     try {
       await this.downloadScaffoldsRepo(scaffoldUrl)
-      await this.extractSubfolderToTarget(flagScaffold)
+      await this.extractPackageIfExists(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
       throw new CLIError(chalk.red(`Download of scaffold structure failed with error: ${err}`))

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -11,6 +11,14 @@ import * as AdmZip from 'adm-zip'
 import * as chalk from 'chalk'
 import { CLIError } from '@oclif/errors'
 
+async function tryCleanUp (path: string) {
+  try {
+    await cleanDirectory(path)
+  } catch (err) {
+    console.log(chalk.yellow(`Failed to clean up ${path}`))
+  }
+}
+
 export default class New extends Command {
   static description = 'generates a bare bones app locally for development'
 
@@ -85,12 +93,8 @@ export default class New extends Command {
   }
 
   async cleanAfterError () {
-    await cleanDirectory(this.unzippedScaffoldPath)
-    try {
-      await cleanDirectory(this.zipScaffoldPath)
-    } catch (err) {
-      console.log(chalk.yellow(`Failed to clean up ${this.zipScaffoldPath}`))
-    }
+    await tryCleanUp(this.unzippedScaffoldPath)
+    await tryCleanUp(this.zipScaffoldPath)
   }
 
   async run () {
@@ -118,11 +122,7 @@ export default class New extends Command {
 
     fs.renameSync(path.join(process.cwd(), scaffoldDir), path.join(process.cwd(), directoryName))
     this.modifyManifest(directoryName, appName, authorName, authorEmail, flagScaffold)
-    try {
-      await cleanDirectory(this.zipScaffoldPath)
-    } catch (err) {
-      console.log(chalk.yellow(`Failed to clean up ${this.zipScaffoldPath}`))
-    }
+    await tryCleanUp(this.zipScaffoldPath)
     console.log(chalk.green(`Successfully created new project ${directoryName}`))
   }
 }

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -84,6 +84,15 @@ export default class New extends Command {
     updateManifestFile(manifestPath[flagScaffold], manifest)
   }
 
+  async cleanAfterError() {
+    await cleanDirectory(this.unzippedScaffoldPath)
+    try {
+      await cleanDirectory(this.zipScaffoldPath)
+    } catch (err) {
+      console.log(chalk.yellow(`Failed to clean up ${this.zipScaffoldPath}`))
+    }
+  }
+
   async run () {
     const { flags } = this.parse(New)
     const flagScaffold = flags.scaffold
@@ -103,7 +112,7 @@ export default class New extends Command {
       await this.extractScaffoldIfExists(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
-      await cleanDirectory(this.unzippedScaffoldPath)
+      await this.cleanAfterError()
       throw new CLIError(chalk.red(`Download of scaffold structure failed with error: ${err}`))
     }
 

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -51,8 +51,8 @@ export default class New extends Command {
       destination.on('finish', () => {
         const zip = new AdmZip(this.zipScaffoldPath)
         const overwrite = false
-        zip.extractAllToAsync(path.join(process.cwd()), overwrite, (err) => {
-          tryCleanUp(this.zipScaffoldPath)
+        zip.extractAllToAsync(path.join(process.cwd()), overwrite, async (err) => {
+          await tryCleanUp(this.zipScaffoldPath)
           if (err) {
             reject(err)
           }
@@ -67,8 +67,8 @@ export default class New extends Command {
       fsExtra.copy(
         path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
         path.join(process.cwd(), directoryName),
-        { overwrite: true, errorOnExist: true }, (err: FsExtraError) => {
-          tryCleanUp(this.unzippedScaffoldPath)
+        { overwrite: true, errorOnExist: true }, async (err: FsExtraError) => {
+          await tryCleanUp(this.unzippedScaffoldPath)
           if (err) {
             if (err.code === 'ENOENT') {
               reject(new Error(`Scaffold ${flagScaffold} does not exist: ${err}`))

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -11,14 +11,6 @@ import * as AdmZip from 'adm-zip'
 import * as chalk from 'chalk'
 import { CLIError } from '@oclif/errors'
 
-async function tryCleanUp (path: string) {
-  try {
-    await cleanDirectory(path)
-  } catch (err) {
-    console.log(chalk.yellow(`Failed to clean up ${path}`))
-  }
-}
-
 export default class New extends Command {
   static description = 'generates a bare bones app locally for development'
 
@@ -52,7 +44,7 @@ export default class New extends Command {
         const zip = new AdmZip(this.zipScaffoldPath)
         const overwrite = false
         zip.extractAllToAsync(path.join(process.cwd()), overwrite, async (err) => {
-          await tryCleanUp(this.zipScaffoldPath)
+          await cleanDirectory(this.zipScaffoldPath)
           if (err) {
             reject(err)
           }
@@ -68,7 +60,7 @@ export default class New extends Command {
         path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
         path.join(process.cwd(), directoryName),
         { overwrite: true, errorOnExist: true }, async (err: FsExtraError) => {
-          await tryCleanUp(this.unzippedScaffoldPath)
+          await cleanDirectory(this.unzippedScaffoldPath)
           if (err) {
             if (err.code === 'ENOENT') {
               reject(new Error(`Scaffold ${flagScaffold} does not exist: ${err}`))

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -53,11 +53,11 @@ export default class New extends Command {
     })
   }
 
-  async extractSubfolderToTarget (scaffoldName: string, targetName: string) {
+  async extractSubfolderToTarget (flagScaffold: string) {
     return new Promise((resolve, reject) => {
       fsExtra.copy(
-        path.join(process.cwd(), '/', scaffoldName, '/packages/', targetName),
-        path.join(process.cwd(), '/', `${scaffoldName}-${targetName}`),
+        path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
+        path.join(process.cwd(), '/', `app_scaffolds-master-${flagScaffold}`),
         { overwrite: true, errorOnExist: true }, (err) => {
           if (err) {
             reject(err)
@@ -66,14 +66,6 @@ export default class New extends Command {
         }
       )
     })
-  }
-
-  getScaffoldDir (flagScaffold: string): string {
-    const scaffoldRepo = 'app_scaffolds'
-    if (!scaffoldRepo) {
-      throw new CLIError(chalk.red(`Invalid scaffold option entered ${flagScaffold}`))
-    }
-    return scaffoldRepo
   }
 
   modifyManifest (directoryName: string, appName: string, authorName: string, authorEmail: string, flagScaffold: string) {
@@ -100,21 +92,18 @@ export default class New extends Command {
       authorEmail = flags.authorEmail || await cli.prompt('Enter this app authors email')
     }
     const appName = flags.appName || await cli.prompt('Enter a name for this new app')
-    const scaffoldRepo = this.getScaffoldDir(flagScaffold)
-    const scaffoldDir = scaffoldRepo + '-master'
-    const scaffoldDirWithType = scaffoldDir + '-' + flagScaffold
-
-    const scaffoldUrl = `https://codeload.github.com/zendesk/${scaffoldRepo}/zip/master`
+    const scaffoldDir = 'app_scaffolds-master-' + flagScaffold
+    const scaffoldUrl = 'https://codeload.github.com/zendesk/app_scaffolds/zip/master'
 
     try {
       await this.downloadScaffold(scaffoldUrl)
-      await this.extractSubfolderToTarget(scaffoldDir, flagScaffold)
+      await this.extractSubfolderToTarget(flagScaffold)
       await cleanDirectory(this.unzippedScaffoldPath)
     } catch (err) {
       throw new CLIError(chalk.red('Download of scaffold structure failed'))
     }
 
-    fs.renameSync(path.join(process.cwd(), scaffoldDirWithType), path.join(process.cwd(), directoryName))
+    fs.renameSync(path.join(process.cwd(), scaffoldDir), path.join(process.cwd(), directoryName))
     this.modifyManifest(directoryName, appName, authorName, authorEmail, flagScaffold)
     try {
       await cleanDirectory(this.zipScaffoldPath)

--- a/packages/zcli-apps/src/types.ts
+++ b/packages/zcli-apps/src/types.ts
@@ -29,6 +29,10 @@ export interface FileList {
     time: number;
 }
 
+export interface FsExtraError extends Error {
+    code: string;
+}
+
 export interface Manifest {
     name?: string;
     author: Author;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,17 +1011,17 @@
     chalk "^2.4.2"
     tslib "^1.9.3"
 
-"@oclif/plugin-autocomplete@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.2.0.tgz#e965ae83abdb81ff97eb7d63a975bcedb78dfdd9"
-  integrity sha512-pHbaE2PH7d9lHjCgFrrQ+ZIwvY+7OAQaGoaANqDbicBNDK/Rszt4N4oGj22dJT7sCQ8a/3Eh942rjxYIq9Mi9Q==
+"@oclif/plugin-autocomplete@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.3.0.tgz#eec788596a88a4ca5170a9103b6c2835119a8fbd"
+  integrity sha512-gCuIUCswvoU1BxDDvHSUGxW8rFagiacle8jHqE49+WnuniXD/N8NmJvnzmlNyc8qLE192CnKK+qYyAF+vaFQBg==
   dependencies:
     "@oclif/command" "^1.5.13"
     "@oclif/config" "^1.13.0"
-    chalk "^2.4.1"
+    chalk "^4.1.0"
     cli-ux "^5.2.1"
     debug "^4.0.0"
-    fs-extra "^7.0.0"
+    fs-extra "^9.0.1"
     moment "^2.22.1"
 
 "@oclif/plugin-help@^2", "@oclif/plugin-help@^2.1.6":
@@ -1566,10 +1566,10 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
-adm-zip@0.4.16:
-  version "0.4.16"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"
-  integrity sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==
+adm-zip@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.5.tgz#b6549dbea741e4050309f1bb4d47c47397ce2c4f"
+  integrity sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
@@ -2251,10 +2251,10 @@ chai@^4:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@4.1.0, chalk@^4.0.0, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+chalk@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2272,6 +2272,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -4001,7 +4009,16 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@3.0.0, form-data@^3.0.0:
+form-data@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
@@ -4058,6 +4075,15 @@ fs-extra@9.0.1, fs-extra@^9.0.1:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^1.0.0"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^6.0.1:
   version "6.0.1"
@@ -8307,7 +8333,7 @@ tslib@^1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^1.14.0:
+tslib@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -8465,6 +8491,11 @@ universalify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
   integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
@zendesk/vegemite 

<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
We should use the new app_scaffolds monorepo for all zcli app scaffolds going forward.

For more information, see https://github.com/zendesk/app_scaffolds.

## Checklist

- [ ] :guardsman: includes new unit and functional tests
