### PR TITLE
feat: support added for an ignore file when packaging

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -97,7 +97,7 @@ EXAMPLES
 
 ## `zcli apps:package APPDIRECTORY`
 
-validates and packages your app
+validates and packages your app.  Will also search for a file called .zcliignore in the package directory.  This acts in the same manner as the .gitignore file in that you can specify files and directories not to be included in the generated package.
 
 ```
 USAGE

--- a/packages/zcli-apps/src/lib/package.ts
+++ b/packages/zcli-apps/src/lib/package.ts
@@ -24,11 +24,23 @@ export const createAppPkg = async (
 
   archive.pipe(output)
 
-  // ignore tmp dir
+  // Check for existance of .zcliignore file & add to the array of items to ignore during packaging
+
+  let archive_ignore = ['tmp/**']
+
+  if (fs.pathExistsSync(`${appPath}/.zcliignore`)) {
+    archive_ignore = archive_ignore.concat(fs.readFileSync(`${appPath}/.zcliignore`).toString().replace(/\r\n/g, '\n').split('\n').filter((item) => {
+      return (item.trim().startsWith('#') ? null : item.trim())
+    }))
+  }
+
+  // ignore tmp dir & .zcliignore entries if found
+
   archive.glob('**', {
     cwd: appPath,
-    ignore: ['tmp/**']
+    ignore: archive_ignore
   })
+
   await archive.finalize()
 
   if (!fs.pathExistsSync(pkgPath)) {


### PR DESCRIPTION
support added to the apps:package command for a .gitignore like file called .zcliignore that allows an app developer to specify a list of directories and files that should not be included in the package .zip file when generated.  Update to documentation describing this change also added.
