### PR TITLE
[VEG-662] Improve release and automate process

### DIFF
--- a/.github/workflows/publish_artifactory.yml
+++ b/.github/workflows/publish_artifactory.yml
@@ -1,0 +1,32 @@
+name: publish
+
+on:
+  push:
+    branches: master
+
+jobs:
+  main:
+    name: tag_and_publish
+    runs-on: zendesk-stable
+    steps:
+    - uses: zendesk/checkout@v2
+      with:
+        token: ${{ secrets.ORG_GITHUB_WRITE_TOKEN }}
+    - uses: zendesk/setup-node@v2.1.2
+      with:
+        node-version: '12.x'
+    - uses: zendesk/ga/tag-semantic-release@v2
+      id: tag
+      with:
+        github-token: ${{ secrets.ORG_GITHUB_WRITE_TOKEN }}
+        version-type: patch
+    - name: build_on_merge
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        npm install
+        npm run build
+        npm version ${{ steps.tag.outputs.version }} --force -m "Upgrade to %s from github actions build_on_merge step [ci skip]"
+        npm publish
+        npm run release
+        

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "lint": "eslint . --ext .ts --config .eslintrc",
     "test": "nyc --extension .ts mocha --opts mocha.opts --forbid-only packages/**/src/**/*.test.ts",
     "test:functional": "mocha -r ts-node/register packages/**/tests/**/*.test.ts",
-    "changelog": "lerna-changelog"
+    "changelog": "lerna-changelog",
+    "release": "./scripts/release.sh"
   },
   "license": "Apache-2.0",
   "licenses": [
@@ -60,5 +61,8 @@
     }
   ],
   "repository": "zendesk/zcli",
-  "types": "lib/index.d.ts"
+  "types": "lib/index.d.ts",
+  "publishConfig": {
+    "registry": "https://zdrepo.jfrog.io/zdrepo/api/npm/npm"
+  }
 }


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
At the moment ZCLI needs a manual release and will only publish to the NPM registry. This PR aims to include publish artifactory and automate the release on merge to master.
https://zendesk.atlassian.net/browse/VEG-662 
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
