### PR TITLE
docs: Add note to README on running ZCLI on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Depending on your distribution, you will need to run one of the following comman
 - Red Hat-based: `sudo yum install libsecret-devel`
 - Arch Linux: `sudo pacman -S libsecret`
 
+## Note for Windows users running Linux on WSL
+
+ZCLI's credential manager has a dependency on Linux's windowing manager (X11) which will make some commands fail to run on WSL, unless you run a setup of WSL with support for X11/GUI apps. These commands include: `zcli login`, `zcli logout` and `zcli profiles`.
+
+There is a number of workarounds for this, but they are quite convoluted including:
+
+* Manually starting a DBus session and unlocking the Gnome keyring with a password supplied via STDIN
+* Using X11 forwarding to be able to enable the Gnome keyring prompt to display
+
+A better approach might be to await the upcoming support for GUI apps in WSL2 that Microsoft is [working on](https://youtu.be/f8_nvJzuaSU) and that is currently in [Preview](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
+
+Features of ZCLI not dependent on ZCLI's credential manager should work in WSL2 w/o X11 support.
+
 # Project structure
 
 This is a monorepo project powered by lerna and yarn workspaces. It contains multiple packages:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ Depending on your distribution, you will need to run one of the following comman
 
 ZCLI's credential manager has a dependency on Linux's windowing manager (X11) which will make some commands fail to run on WSL, unless you run a setup of WSL with support for X11/GUI apps. These commands include: `zcli login`, `zcli logout` and `zcli profiles`.
 
-There is a number of workarounds for this, but they are quite convoluted including:
+Features of ZCLI not dependent on ZCLI's credential manager should work in WSL2 w/o X11 support.
+
+There is a number of workarounds:
 
 * Manually starting a DBus session and unlocking the Gnome keyring with a password supplied via STDIN
 * Using X11 forwarding to be able to enable the Gnome keyring prompt to display
 
-A better approach might be to await the upcoming support for GUI apps in WSL2 that Microsoft is [working on](https://youtu.be/f8_nvJzuaSU) and that is currently in [Preview](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
+**Windows 11 users**
 
-Features of ZCLI not dependent on ZCLI's credential manager should work in WSL2 w/o X11 support.
+A better approach might be to await the upcoming support for GUI apps in WSL2 that Microsoft is [working on](https://youtu.be/f8_nvJzuaSU) and that is currently in [Preview](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
 
 # Project structure
 


### PR DESCRIPTION
## Description

Adds a note to the README for Windows WSL users that are having issues running certain commands like `zcli login` and `zcli profiles` because WSL currently lack GUI support and ZCLI's credential manager depends on it.

## Detail

Closes [#56](https://github.com/zendesk/zcli/issues/56)