### PR TITLE
[VEG-694] Allow zcli apps:server to work on chat

### DIFF
--- a/packages/zcli-apps/src/commands/apps/server.ts
+++ b/packages/zcli-apps/src/commands/apps/server.ts
@@ -11,6 +11,12 @@ const logMiddleware = morgan((tokens, req, res) =>
   `${chalk.green(tokens.method(req, res))} ${tokens.url(req, res)} ${chalk.bold(tokens.status(req, res))}`
 )
 
+const ZENDESK_DOMAINS_REGEX = new RegExp('^http(?:s)?://[a-z0-9-]+.(?:zendesk|zopim|futuresimple|local.futuresimple|zendesk-(?:dev|master|staging)).com')
+
+const request_from_zendesk = (req: any): boolean => {
+  return ZENDESK_DOMAINS_REGEX.test(req.get('HTTP_ORIGIN'))
+}
+
 export default class Server extends Command {
   static description = 'serves apps in development mode'
 
@@ -49,6 +55,10 @@ export default class Server extends Command {
     tailLogs && app.use(logMiddleware)
 
     app.get('/app.json', (req, res) => {
+      if (request_from_zendesk(req)) {
+        const httpAccessControlRequestHeaders = req.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS') || ''
+        res.setHeader('Access-Control-Allow-Headers', httpAccessControlRequestHeaders)
+      }
       res.setHeader('Content-Type', 'application/json')
       res.end(JSON.stringify(appJSON))
     })


### PR DESCRIPTION
@zendesk/vegemite 
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
In ZAT, we use logic to check a regular expression as to whether the domain is a Zendesk domain.  If so, we append an access control header to the fetch request if the origin resource has such headers attached.

This change emulates this behaviour in ZCLI.

Before making this change, `zcli apps:server` for an app with a chat_sidebar location that is in an account with Agent Workspace disabled fails to load in a chat conversation.  `zat server` has no such limitation.

After making this change, `zcli apps:server` successfully serves said app.

## Checklist

- [ ] :guardsman: includes new unit and functional tests
