### PR TITLE
Remove auto doc gen for now

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,7 +6,9 @@ set -e
 echo '🔄 Generate tag, update docs and changelog'
 yarn install
 
-./scripts/generate_dev_docs.sh
+# TODO: move custom docs part of app.md etc to another place,
+# so we can continue to run generate_dev_docs.sh script
+# ./scripts/generate_dev_docs.sh
 
 # Remove beta once we are out of it
 npx lerna publish --conventional-commits --yes --preid 'beta'


### PR DESCRIPTION
## Description

Remove auto doc gen for now given we have some custom docs which we don't want to be overriden.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
