### PR TITLE
[VEG-871] Remove wait by spying on setAppAssetsMiddleware

### DIFF
--- a/packages/zcli-apps/tests/functional/server.test.ts
+++ b/packages/zcli-apps/tests/functional/server.test.ts
@@ -108,6 +108,8 @@ describe('apps server', function () {
           manifest.name = `${appName} modified`
           // Modify manifest.json
           await fsPromise.writeFile(manifestPath, JSON.stringify(manifest))
+          // Wait for setAppAssetsMiddleware() spy to be called to ensure that change has been written
+          // TODO implement spy on said method here and/or however this works in Cypress / Puppeteer perhaps on the route
           const response = await fetch(`${appHost}/app.json`)
           appsJSON = await response.json()
           const appJSON = appsJSON.apps[index]

--- a/packages/zcli-apps/tests/functional/server.test.ts
+++ b/packages/zcli-apps/tests/functional/server.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@oclif/test'
 import * as path from 'path'
 import * as http from 'http'
 import fetch from 'node-fetch'
+import { promises as fsPromise } from 'fs'
 import * as fs from 'fs'
 import { omit } from 'lodash'
 import ServerCommand from '../../src/commands/apps/server'
@@ -105,16 +106,15 @@ describe('apps server', function () {
           const manifest: Manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
           const appName = manifest.name
           manifest.name = `${appName} modified`
-          // Modifed manifest.json
-          fs.writeFileSync(manifestPath, JSON.stringify(manifest))
-          await wait()
+          // Modify manifest.json
+          await fsPromise.writeFile(manifestPath, JSON.stringify(manifest))
           const response = await fetch(`${appHost}/app.json`)
           appsJSON = await response.json()
           const appJSON = appsJSON.apps[index]
           expect(appJSON.name).to.eq(`${appName} modified`)
-          // Restored manifest.json
+          // Restore manifest.json
           manifest.name = appName
-          fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+          await fsPromise.writeFile(manifestPath, JSON.stringify(manifest, null, 2))
         }))
       })
   })


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

We should avoid waits, even in test code.  Let's see if we can clean things up a bit by spying on the appropriate middleware to wait until it has been called before proceeding with the rest of the test.
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
