### PR TITLE
Make sure that we use our mocha.opts in our functional tests too

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "link:bin": "lerna link && lerna run install:zcli",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "test": "nyc --extension .ts mocha --opts mocha.opts --forbid-only packages/**/src/**/*.test.ts",
-    "test:functional": "mocha -r ts-node/register packages/**/tests/**/*.test.ts",
+    "test:functional": "mocha --opts mocha.opts -r ts-node/register packages/**/tests/**/*.test.ts",
     "changelog": "lerna-changelog",
     "type:check": "lerna run type:check"
   },


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
There are occasional flakes in the functional tests (see eg here https://github.com/zendesk/zcli/runs/4425701072?check_suite_focus=true) basically caused by the fact that the default timeout of 2000ms is not enough.  We set the timeout to 5000ms in the standard unit tests, so let's use this option in our functional tests too.

## Checklist

- [ ] :guardsman: includes new unit and functional tests
