### PR TITLE
ReadMe in Docs folder for navigability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
 # Contents
 
-1. CLI
+1. [ZCLI Apps](./apps.md) <br /> zcli apps commands helps with managing Zendesk apps workflow.
+2. [Autocomplete](./autocomplete.md) <br /> display autocomplete installation instructions
+3. [Help](./help.md) <br />  display help for zcli
+4. [Login](./loogin.md) <br />  creates and/or saves an authentication token for the specified subdomain
+5. [Logout](./logout.md) <br />  removes an authentication token for an active profile
+6. [Profiles](./profiles.md) <br />  manage cli user profiles
+7. [Update](/update.md)  <br /> describe the command here

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Contents
+
+1. CLI

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -1,0 +1,4 @@
+
+# Contents
+
+1. CLI

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -1,4 +1,0 @@
-
-# Contents
-
-1. CLI


### PR DESCRIPTION
Adds a readme in the docs folder to make it clear what each markdown document contains

## Description

A simple TOC for the docs folder

## Detail

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/2160666/154384689-f7e135bb-63a8-487f-b8c5-ee42b62671a7.png">
