### PR TITLE
Add link to app scaffolds for ZAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ This project contains multi product cli commands and contains packages per produ
 
 For a full reference, see the [documentation.](/docs)
 
+# ZAF App Scaffolding
+
+Some useful app scaffolds for build ZAF apps that incorporate the ZCLI tool are avaliable at [zendesk/app_scaffolds](https://github.com/zendesk/app_scaffolds)
+
 # Releasing
 
 Running the following command will create release tags, generate change logs docs and publish to npm.


### PR DESCRIPTION
## Description

It's currently hard to find and connect all the different parts of the Zendesk App Framework as it evolves...   conflicting scaffold repos exist (zendesk/app_scaffold and zendesk/app_scaffolds).

This should help people find the correct up-to-date scaffolds.