### PR TITLE
[VEG-1077] Handle case where installation location is a string and not an object

### DIFF
--- a/packages/zcli-apps/src/lib/buildAppJSON.test.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.test.ts
@@ -64,20 +64,17 @@ const multiProductLocations = {
   sell: {
     top_bar: {
       url: 'assets/iframe.html',
-      svg: 'sell/icon_top_bar.svg',
-      flexible: true
+      svg: 'sell/icon_top_bar.svg'
     }
   },
   support: {
     ticket_editor: {
       url: 'assets/iframe.html',
-      svg: 'support/icon_ticket_editor.svg',
-      flexible: true
+      svg: 'support/icon_ticket_editor.svg'
     },
     nav_bar: {
       url: 'assets/iframe.html',
-      svg: 'support/icon_nav_bar.svg',
-      flexible: true
+      svg: 'support/icon_nav_bar.svg'
     }
   }
 }

--- a/packages/zcli-apps/src/lib/buildAppJSON.test.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.test.ts
@@ -64,17 +64,20 @@ const multiProductLocations = {
   sell: {
     top_bar: {
       url: 'assets/iframe.html',
-      svg: 'sell/icon_top_bar.svg'
+      svg: 'sell/icon_top_bar.svg',
+      flexible: true
     }
   },
   support: {
     ticket_editor: {
       url: 'assets/iframe.html',
-      svg: 'support/icon_ticket_editor.svg'
+      svg: 'support/icon_ticket_editor.svg',
+      flexible: true
     },
     nav_bar: {
       url: 'assets/iframe.html',
-      svg: 'support/icon_nav_bar.svg'
+      svg: 'support/icon_nav_bar.svg',
+      flexible: true
     }
   }
 }

--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -73,7 +73,8 @@ const mergeLocationAndIcons = (locations: Location, locationIcons: LocationIcons
     for (const locationName in locationIcons[product]) {
       if (typeof (locations[product][locationName]) === 'string') {
         locations[product][locationName] = {
-          url: locations[product][locationName]
+          url: locations[product][locationName],
+          flexible: true
         }
       }
       if (locationIcons[product][locationName].svg) {
@@ -87,6 +88,17 @@ const mergeLocationAndIcons = (locations: Location, locationIcons: LocationIcons
       }
       if (locationIcons[product][locationName].hover) {
         locations[product][locationName].hover = locationIcons[product][locationName].hover
+      }
+    }
+  }
+  // Handle the case where an app installation location is not an object but is a string.
+  for (const product in locations) {
+    for (const locationName in locations[product]) {
+      if (typeof (locations[product][locationName]) === 'string') {
+        locations[product][locationName] = {
+          url: locations[product][locationName],
+          flexible: true
+        }
       }
     }
   }

--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -75,13 +75,6 @@ const mergeLocationAndIcons = (locations: Location, locationIcons: LocationIcons
         locations[product][locationName] = {
           url: locations[product][locationName]
         }
-        // Default as flexible app in Support: https://support.zendesk.com/hc/en-us/articles/4409156018586-New-Flexible-Property-in-the-Manifest-File-for-Support-Apps-to-Denote-Responsiveness
-        if (product === 'support' && (locations[product][locationName] === 'ticket_sidebar' || locations[product][locationName] === 'new_ticket_sidebar')) {
-          locations[product][locationName] = {
-            flexible: true,
-            ...locations[product][locationName]
-          }
-        }
       }
       if (locationIcons[product][locationName].svg) {
         locations[product][locationName].svg = locationIcons[product][locationName].svg
@@ -103,13 +96,6 @@ const mergeLocationAndIcons = (locations: Location, locationIcons: LocationIcons
       if (typeof (locations[product][locationName]) === 'string') {
         locations[product][locationName] = {
           url: locations[product][locationName]
-        }
-        // Default as flexible app in Support: https://support.zendesk.com/hc/en-us/articles/4409156018586-New-Flexible-Property-in-the-Manifest-File-for-Support-Apps-to-Denote-Responsiveness
-        if (product === 'support' && (locations[product][locationName] === 'ticket_sidebar' || locations[product][locationName] === 'new_ticket_sidebar')) {
-          locations[product][locationName] = {
-            flexible: true,
-            ...locations[product][locationName]
-          }
         }
       }
     }

--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -73,8 +73,14 @@ const mergeLocationAndIcons = (locations: Location, locationIcons: LocationIcons
     for (const locationName in locationIcons[product]) {
       if (typeof (locations[product][locationName]) === 'string') {
         locations[product][locationName] = {
-          url: locations[product][locationName],
-          flexible: true
+          url: locations[product][locationName]
+        }
+        // Default as flexible app in Support: https://support.zendesk.com/hc/en-us/articles/4409156018586-New-Flexible-Property-in-the-Manifest-File-for-Support-Apps-to-Denote-Responsiveness
+        if (product === 'support' && (locations[product][locationName] === 'ticket_sidebar' || locations[product][locationName] === 'new_ticket_sidebar')) {
+          locations[product][locationName] = {
+            flexible: true,
+            ...locations[product][locationName]
+          }
         }
       }
       if (locationIcons[product][locationName].svg) {
@@ -91,13 +97,19 @@ const mergeLocationAndIcons = (locations: Location, locationIcons: LocationIcons
       }
     }
   }
-  // Handle the case where an app installation location is not an object but is a string.
+  // Handle the case where an app installation location is not an object but is a string,
   for (const product in locations) {
     for (const locationName in locations[product]) {
       if (typeof (locations[product][locationName]) === 'string') {
         locations[product][locationName] = {
-          url: locations[product][locationName],
-          flexible: true
+          url: locations[product][locationName]
+        }
+        // Default as flexible app in Support: https://support.zendesk.com/hc/en-us/articles/4409156018586-New-Flexible-Property-in-the-Manifest-File-for-Support-Apps-to-Denote-Responsiveness
+        if (product === 'support' && (locations[product][locationName] === 'ticket_sidebar' || locations[product][locationName] === 'new_ticket_sidebar')) {
+          locations[product][locationName] = {
+            flexible: true,
+            ...locations[product][locationName]
+          }
         }
       }
     }


### PR DESCRIPTION
@zendesk/vegemite 
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
`zcli apps:server` should handle a manifest wherein an installation location looks like this:

```
"location": {
  "support": {
    "ticket_sidebar": "assets/iframe.html"
  }
},
```

and serve it locally if `?zcli_apps=true` is mounted to a test account.

Currently there is a javascript error presented with the current zcli tag, this is because for whatever reason this usecase was overlooked during development of zcli to date.

We should also continue to support manifest installation locations of the following form:

```
"location": {
  "support": {
    "ticket_sidebar": {
      "autoHide": true,
      "flexible": true,
      "signed": true,
      "url": "https://myapp.example.org/",
      "size": {
        "height": "220px"
      }
    }
  }
},
```

## References

Developer docs page: https://developer.zendesk.com/documentation/apps/app-developer-guide/manifest/#location.

## Checklist

- [ ] :guardsman: includes new unit and functional tests
