### PR TITLE
chore: improve error message when not logged in by telling user what to do

### DIFF
--- a/packages/zcli-core/src/lib/request.ts
+++ b/packages/zcli-core/src/lib/request.ts
@@ -39,5 +39,5 @@ export const requestAPI = async (url: string, options: any = {}, json = false) =
     return fetch(`https://${subdomain}.zendesk.com/${url}`, options)
   }
 
-  throw new CLIError(chalk.red('Authorization Failed, try logging in!'))
+  throw new CLIError(chalk.red('Authorization Failed, try logging in via `zcli login -i`!'))
 }


### PR DESCRIPTION
## Description

I just used `zcli` for the first time and ran into the same problem as described in #11 . With the displayed error message it was not clear what I needed to do, because it is not obvious that `zcli` sends a request to the zendesk server. 

This PR adds the command one needs to run to the error message to make it more obvious what the user needs to do.

Side note: This `zcli login` step also doesn't seem to be documented in the [How-to Guide](https://developer.zendesk.com/documentation/apps/build-an-app/build-your-first-support-app/part-5-installing-the-app-in-zendesk-support/).

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
