### PR TITLE
Add github action to check zcli works when packed

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,0 +1,21 @@
+name: Pack
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: zendesk/checkout@v2
+    - name: Use Node.js
+      uses: zendesk/setup-node@v2.1.2
+      with:
+        node-version: '14.x'
+    - run: yarn pack && npm install -g file:/home/runner/work/zcli/zcli/zcli-monorepo-v0.0.1.tgz
+    - run: zcli-monorepo -v
+      env:
+        CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn-error.log
 .vscode
 packages/zcli-apps/tests/functional/mocks/*/tmp
 packages/**/dist
+zcli-monorepo*


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

We've had issues with devDependencies not being present when zcli is
shipped, the purpose of this action is to doublecheck that basic zcli
commands work before merge.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
