### PR TITLE
docs: update required node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more about ZCLI see [the full documentation.](/docs)
 
 This is a [Node.js](https://nodejs.org/en/) module available through the [npm registry.](https://www.npmjs.com/package/@zendesk/zcli)
 
-Before installing, download and install Node.js. Node.js 12.10 or higher is required. Installation is done using the npm install command:
+Before installing, download and install Node.js. Node.js 14.17.3 or higher is required. Installation is done using the npm install command:
 
 ```
 $ npm install @zendesk/zcli -g
@@ -26,7 +26,7 @@ $ npm install @zendesk/zcli -g
 Currently ZCLI has a dependency on `libsecret` to save authentication information securely in the operating system's keychain.
 
 Depending on your distribution, you will need to run one of the following commands prior to installing ZCLI:
-- Debian/Ubuntu: `sudo apt-get install libsecret-1-dev`
+- Debian/Ubuntu: `sudo apt install libsecret-1-dev`
 - Red Hat-based: `sudo yum install libsecret-devel`
 - Arch Linux: `sudo pacman -S libsecret`
 

--- a/packages/zcli/README.md
+++ b/packages/zcli/README.md
@@ -4,7 +4,7 @@ $ npm install -g @zendesk/zcli
 $ zcli COMMAND
 running command...
 $ zcli --version
-@zendesk/zcli/1.0.0-beta.3 darwin-x64 node-v14.17.3
+@zendesk/zcli/1.0.0-beta.23 darwin-x64 node-v14.17.3
 $ zcli --help [COMMAND]
 USAGE
   $ zcli COMMAND

--- a/packages/zcli/README.md
+++ b/packages/zcli/README.md
@@ -3,8 +3,8 @@
 $ npm install -g @zendesk/zcli
 $ zcli COMMAND
 running command...
-$ zcli (-v|--version|version)
-@zendesk/zcli/1.0.0-beta.3 darwin-x64 node-v12.10.0
+$ zcli --version
+@zendesk/zcli/1.0.0-beta.3 darwin-x64 node-v14.17.3
 $ zcli --help [COMMAND]
 USAGE
   $ zcli COMMAND


### PR DESCRIPTION
## Description

Updates required node version to Node.js 14.17.3.
Updates Debian/Ubuntu `apt` command.
Updates the `zcli --version` command. `zcli -v` and `zcli version` are no longer supported.

## Checklist

- [ ] :guardsman: includes new unit and functional tests
