### PR TITLE
Always publish to npmjs.com main public registry

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,6 @@ yarn install
 # ./scripts/generate_dev_docs.sh
 
 # Remove beta once we are out of it
-npx lerna publish --conventional-commits --yes --preid 'beta'
+npx lerna publish --conventional-commits --yes --preid 'beta' --@zendesk:registry=https://npmjs.com
 echo "✅ Done"
 exit 0


### PR DESCRIPTION
## Description

Make sure that we always publish to the main npmjs.com public registry.

Note, we use --@zendesk:registry=https://npmjs.com because configuration
in ~/.npmrc will override --registry=https://npmjs.com if set. [1]

[1]: https://stackoverflow.com/a/67691043

## Checklist

- [ ] :guardsman: includes new unit and functional tests
