### PR TITLE
Revert "Always publish to npmjs.com main public registry"

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,6 @@ yarn install
 # ./scripts/generate_dev_docs.sh
 
 # Remove beta once we are out of it
-npx lerna publish --conventional-commits --yes --preid 'beta' --@zendesk:registry=https://npmjs.com
+npx lerna publish --conventional-commits --yes --preid 'beta'
 echo "✅ Done"
 exit 0


### PR DESCRIPTION
Reverts zendesk/zcli#132

Lerna doesn't support the full medley on npm commands, so --@zendesk:registry=https://registry.npmjs.org or otherwise is nonsense to lerna.