### PR TITLE
Remove yarn link:bin script

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ If you'd like to take a crack at making some changes, please refer to [our contr
 
 You can run `yarn --cwd /path/to/zcli dev` in a development environment without transpiling ZCLI into JavaScript.
 
+For example, to test `zcli apps:server` on [v2 REPL](https://github.com/zendesk/v2_repl_app):
+
+```sh
+cd /path/to/v2_repl_app
+# make sure we are using the same Node.js version
+ln -s /path/to/zcli/.node-version
+# please build v2 REPL in advance
+# see https://github.com/zendesk/v2_repl_app for details
+yarn --cwd /path/to/zcli dev apps:server "$PWD/dist"
+```
+
 # ZAF App Scaffolding
 
 Some useful app scaffolds for build ZAF apps that incorporate the ZCLI tool are avaliable at [zendesk/app_scaffolds](https://github.com/zendesk/app_scaffolds)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Got issues with what you find here? You can [create an issue on Github](https://
 
 If you'd like to take a crack at making some changes, please refer to [our contributing guide](.github/CONTRIBUTING.md). 
 
+# Local development
+
+You can run `yarn --cwd /path/to/zcli dev` in a development environment without transpiling ZCLI into JavaScript.
+
 # ZAF App Scaffolding
 
 Some useful app scaffolds for build ZAF apps that incorporate the ZCLI tool are avaliable at [zendesk/app_scaffolds](https://github.com/zendesk/app_scaffolds)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "postinstall": "lerna bootstrap",
     "dev": "ts-node ./packages/zcli/bin/run",
     "git:check": "./scripts/git_check.sh",
-    "link:bin": "lerna link && lerna run install:zcli",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "test": "nyc --extension .ts mocha --config=.mocharc.json --forbid-only packages/**/src/**/*.test.ts",
     "test:functional": "mocha --config=.mocharc.json -r ts-node/register packages/**/tests/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "rimraf": "^3.0.2",
     "standard": "^17.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4",
+    "typescript": "~4.7.4",
     "yarn-audit-fix": "^9.3.1"
   },
   "engines": {

--- a/packages/zcli/package.json
+++ b/packages/zcli/package.json
@@ -60,7 +60,6 @@
     }
   },
   "scripts": {
-    "install:zcli": "rimraf package-lock.json && npm link",
     "prepack": "tsc && ../../scripts/prepack.sh",
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json && rm -rf ./dist && git checkout ./package.json",
     "type:check": "tsc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7625,7 +7625,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.7.4:
+typescript@~4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

### 88e105aba224898329ea55f170799da3759d85f9 Remove yarn link:bin script

To adopt TypeScript, we previously used ts-node [1] in [2] as our
shebang. However this required user to install ts-node as a sibling
global dependency and effectively stopped using transpiled JavaScript
files.

So in [3] we reverted back to node to fix the issue in distribution.
However locally when using `yarn/npm link`, it still links that very
same script to global binary directory. Since locally we don't keep the
JavaScript files (we only transpile them when packaging/publishing), it
rendered the `yarn link:bin` setup broken.

As it stands now, it's easier and more straightforward to rely on `yarn
dev` which feeds the `run` script into ts-node, overriding its shebang.

[1] https://github.com/TypeStrong/ts-node
[2] https://github.com/zendesk/zcli/commit/2b799dcc33a8aabdc092010a937619755a60577a
[3] https://github.com/zendesk/zcli/commit/0f59937e13538120c37693637508736c77e8f582


### ce8e79a0d36f50a6af3d0919d69d027e2a3a8ffe Pin TypeScript to <4.8 to avoid oclif/core error

See [1]. oclif/core doesn't transpile using TypeScript 4.8 at the
moment.

[1] https://github.com/oclif/core/issues/482


## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
