### PR TITLE
Set up local ts-node stub for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ ZCLI supports numerous commands. Further documentation on available commands can
 - [`$ zcli autocomplete`](/docs/autocomplete.md) - display autocomplete installation instructions.
 - [`$ zcli help`](/docs/help.md) - display help for zcli
 
+# Local development
+
+To run your development copy of ZCLI locally, execute `yarn link:bin`.
+
+Under macOS if you are using a version manager like [`asdf`](https://asdf-vm.com), it can additionally set up the global `/usr/local/bin/zcli`.
+Note you need global Node.js and [`ts-node`](https://github.com/TypeStrong/ts-node) for this as well.
+
+```sh
+brew install --formula node yarn
+yarn global add ts-node
+```
+
+Under Windows this can only be used in WSL2 or [Cygwin](https://www.cygwin.com).
+
 # Contributing
 
 ---

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "postinstall": "lerna bootstrap",
     "dev": "ts-node ./packages/zcli/bin/run",
     "git:check": "./scripts/git_check.sh",
-    "link:bin": "lerna link && lerna run install:zcli",
+    "link:bin": "./scripts/link_dev.sh",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "test": "nyc --extension .ts mocha --config=.mocharc.json --forbid-only packages/**/src/**/*.test.ts",
     "test:functional": "mocha --config=.mocharc.json -r ts-node/register packages/**/tests/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "postinstall": "lerna bootstrap",
     "dev": "ts-node ./packages/zcli/bin/run",
     "git:check": "./scripts/git_check.sh",
-    "link:bin": "./scripts/link_dev.sh",
+    "link:bin": "bash ./scripts/link_dev.sh",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "test": "nyc --extension .ts mocha --config=.mocharc.json --forbid-only packages/**/src/**/*.test.ts",
     "test:functional": "mocha --config=.mocharc.json -r ts-node/register packages/**/tests/**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "rimraf": "^3.0.2",
     "standard": "^17.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4",
+    "typescript": "~4.7.4",
     "yarn-audit-fix": "^9.3.1"
   },
   "engines": {

--- a/packages/zcli/package.json
+++ b/packages/zcli/package.json
@@ -60,7 +60,6 @@
     }
   },
   "scripts": {
-    "install:zcli": "rimraf package-lock.json && npm link",
     "prepack": "tsc && ../../scripts/prepack.sh",
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json && rm -rf ./dist && git checkout ./package.json",
     "type:check": "tsc"

--- a/scripts/link_dev.sh
+++ b/scripts/link_dev.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+JAVASCRIPT_ENTRYPOINT_PATH="$DIR/../packages/zcli/bin/run"
+
+# link zcli-core & zcli-apps into ./packages/zcli/node_modules/@zendesk/
+npx lerna link
+
+# determine where we should install the stub to
+YARN_GLOBAL_BIN_DIR="$(yarn global bin)"
+TYPESCRIPT_ENTRYPOINT_PATH="$YARN_GLOBAL_BIN_DIR/zcli"
+mkdir -p "$YARN_GLOBAL_BIN_DIR"
+
+printf '\n\nSetting up %s with contents below for ZCLI development\n\n' "$TYPESCRIPT_ENTRYPOINT_PATH"
+touch "$TYPESCRIPT_ENTRYPOINT_PATH"
+chmod +x "$TYPESCRIPT_ENTRYPOINT_PATH"
+tee "$TYPESCRIPT_ENTRYPOINT_PATH" <<EOF
+#!/usr/bin/env bash
+ts-node "$JAVASCRIPT_ENTRYPOINT_PATH" "\$@"
+EOF
+
+TYPESCRIPT_ENTRYPOINT_GLOBAL_PATH='/usr/local/bin/zcli'
+if [[ "$TYPESCRIPT_ENTRYPOINT_PATH" != "/usr"* ]] && [[ -d '/usr/local/bin' ]] &&
+    [[ ! -f "$TYPESCRIPT_ENTRYPOINT_GLOBAL_PATH" ]] && [[ "$OSTYPE" == "darwin"* ]]; then
+    printf '\n'
+    read -r -n1 -p "Do you also want to set up $TYPESCRIPT_ENTRYPOINT_GLOBAL_PATH for global use? [y/n] "
+    printf '\n'
+    if [[ "$REPLY" == 'y' ]]; then
+        ln -s "$TYPESCRIPT_ENTRYPOINT_PATH" "$TYPESCRIPT_ENTRYPOINT_GLOBAL_PATH"
+    fi
+fi
+
+printf '\n\n'
+printf 'Done! If you are using a version manager, you may also want to reshim\n'
+printf 'For example, \e]8;;https://asdf-vm.com\e\\asdf\e]8;;\e\\ reshim nodejs\n'

--- a/scripts/link_dev.sh
+++ b/scripts/link_dev.sh
@@ -4,6 +4,11 @@ set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 JAVASCRIPT_ENTRYPOINT_PATH="$DIR/../packages/zcli/bin/run"
+if [[ "$OSTYPE" == "cygwin" ]]; then
+    # Cygwin relies on foreign Node.js installations, which recognise Windows paths
+    # shellcheck disable=1003
+    JAVASCRIPT_ENTRYPOINT_PATH="$(cygpath -wa "$JAVASCRIPT_ENTRYPOINT_PATH" | tr '\\' '/')"
+fi
 
 # link zcli-core & zcli-apps into ./packages/zcli/node_modules/@zendesk/
 npx lerna link

--- a/yarn.lock
+++ b/yarn.lock
@@ -7625,7 +7625,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.7.4:
+typescript@~4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION

<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

- fix: Pin TypeScript to <4.8 to avoid oclif/core error
- fix: Set up local ts-node stub for development
- fix: Tweak yarn link:bin for Cygwin

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->


### 0a7a2bbf600a8768871bd226131df94db6956c79 fix: Pin TypeScript to <4.8 to avoid oclif/core error

See [1]. oclif/core doesn't transpile using TypeScript 4.8 at the
moment.

[1] https://github.com/oclif/core/issues/482


### c5d09335c487794f1a2377517c5c3a1805f295c0 fix: Set up local ts-node stub for development

To adopt TypeScript, we previously used ts-node [1] in [2] as our
shebang. However this required user to install ts-node as a sibling
global dependency and effectively stopped using transpiled JavaScript
files.

So in [3] we reverted back to node to fix the issue in distribution.
However locally when using `yarn/npm link`, it still links that very
same script to global binary directory. Since locally we don't keep the
JavaScript files (we only transpile them when packaging/publishing), it
rendered the `yarn link:bin` setup broken.

So where we set up a ts-node stub for local development instead. It
should work just like `yarn dev`.

[1] https://github.com/TypeStrong/ts-node
[2] https://github.com/zendesk/zcli/commit/2b799dcc33a8aabdc092010a937619755a60577a
[3] https://github.com/zendesk/zcli/commit/0f59937e13538120c37693637508736c77e8f582


### 8961db8eff7d2482b14f9f182c618374c86e2a2a fix: Tweak yarn link:bin for Cygwin

First of all in link_dev.sh, since foreign Node.js installations are
usually compiled against Windows libraries instead of Cygwin ones, they
often only process Windows paths correctly.

Secondly explicitly defining Bash as the interpreter in package.json,
since Windows doesn't recognise shebang.



## Checklist

- [ ] :guardsman: includes new unit and functional tests
