### PR TITLE
Ma/veg 1468 promt for auth

### DIFF
--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -31,7 +31,7 @@ export default class New extends Command {
   zipScaffoldPath = path.join(process.cwd(), 'scaffold.zip')
   unzippedScaffoldPath = path.join(process.cwd(), 'app_scaffolds-master')
   EMAIL_REGEX = /^.+@.+\..+$/
-  URL_REGEX = /^http(s)?:\/\/?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/
+  URL_REGEX = /^http(s)?:\/\/?[\w.-]+(?:\.[\w-]+)+[\w\-_~:/?#[\]@!&',;=.]+$/
 
   async downloadScaffoldsRepo (url: string) {
     return new Promise<void>((resolve, reject) => {

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -31,7 +31,7 @@ export default class New extends Command {
   zipScaffoldPath = path.join(process.cwd(), 'scaffold.zip')
   unzippedScaffoldPath = path.join(process.cwd(), 'app_scaffolds-master')
   EMAIL_REGEX = /^.+@.+\..+$/
-  URL_REGEX = /[(http(s)?):(www)?a-zA-Z0-9@:%._~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_.~#?&//=]*)/
+  URL_REGEX = /^http(s)?:\/\/?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/
 
   async downloadScaffoldsRepo (url: string) {
     return new Promise<void>((resolve, reject) => {
@@ -108,10 +108,10 @@ export default class New extends Command {
       authorEmail = flags.authorEmail || await CliUx.ux.prompt('Enter this app authors email')
     }
 
-    let authorURL = flags.authorURL || await CliUx.ux.prompt('Enter this apps URL (Optional)', { required: false })
+    let authorURL = flags.authorURL || await CliUx.ux.prompt('Enter this app authors website (optional)', { required: false })
 
     while (authorURL.trim() && !this.URL_REGEX.test(authorURL)) {
-      console.log(chalk.red('Invalid URL, please try again (Press enter to skip)'))
+      console.log(chalk.red('Invalid URL. Please make sure your website begins with "http://" or "https://" and try again (Enter to skip)'))
       authorURL = await CliUx.ux.prompt('Enter this apps URL', { required: false })
     }
 

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -7,7 +7,7 @@ import * as fsExtra from 'fs-extra'
 import * as https from 'https'
 import * as path from 'path'
 import * as AdmZip from 'adm-zip'
-import * as chalk from 'chalk' 
+import * as chalk from 'chalk'
 import { CLIError } from '@oclif/core/lib/errors'
 
 export default class New extends Command {
@@ -31,9 +31,9 @@ export default class New extends Command {
   zipScaffoldPath = path.join(process.cwd(), 'scaffold.zip')
   unzippedScaffoldPath = path.join(process.cwd(), 'app_scaffolds-master')
   EMAIL_REGEX = /^.+@.+\..+$/
-  URL_REGEX = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/
+  URL_REGEX = /[(http(s)?):(www)?a-zA-Z0-9@:%._~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_.~#?&//=]*)/
 
-  async downloadScaffoldsRepo(url: string) {
+  async downloadScaffoldsRepo (url: string) {
     return new Promise<void>((resolve, reject) => {
       const destination = fs.createWriteStream(this.zipScaffoldPath)
 
@@ -55,7 +55,7 @@ export default class New extends Command {
     })
   }
 
-  async extractScaffoldIfExists(flagScaffold: string, directoryName: string) {
+  async extractScaffoldIfExists (flagScaffold: string, directoryName: string) {
     return new Promise<void>((resolve, reject) => {
       fsExtra.copy(
         path.join(process.cwd(), '/', 'app_scaffolds-master/packages/', flagScaffold),
@@ -75,8 +75,8 @@ export default class New extends Command {
     })
   }
 
-  //Added optional "authorURL param to object"
-  modifyManifest(directoryName: string, appName: string, authorName: string, authorEmail: string, flagScaffold: string, authorURL?: string) {
+  // Added optional "authorURL param to object"
+  modifyManifest (directoryName: string, appName: string, authorName: string, authorEmail: string, flagScaffold: string, authorURL?: string) {
     const manifestPath: ManifestPath = {
       basic: path.join(process.cwd(), directoryName),
       react: path.join(process.cwd(), directoryName, 'src')
@@ -89,15 +89,14 @@ export default class New extends Command {
 
     if (authorURL?.trim()) {
       manifest.author.url = authorURL
-    }
-    else {
+    } else {
       delete manifest.author.url
     }
-    
+
     updateManifestFile(manifestPath[flagScaffold], manifest)
   }
 
-  async run() {
+  async run () {
     const { flags } = await this.parse(New)
     const flagScaffold = flags.scaffold
     const directoryName = flags.path || await CliUx.ux.prompt('Enter a directory name to save the new app (will create the dir if it does not exist)')
@@ -110,7 +109,7 @@ export default class New extends Command {
     }
 
     let authorURL = flags.authorURL || await CliUx.ux.prompt('Enter this apps URL (Optional)', { required: false })
-    
+
     while (authorURL.trim() && !this.URL_REGEX.test(authorURL)) {
       console.log(chalk.red('Invalid URL, please try again (Press enter to skip)'))
       authorURL = await CliUx.ux.prompt('Enter this apps URL', { required: false })
@@ -118,7 +117,7 @@ export default class New extends Command {
 
     const appName = flags.appName || await CliUx.ux.prompt('Enter a name for this new app')
     const scaffoldUrl = 'https://codeload.github.com/zendesk/app_scaffolds/zip/master'
-    
+
     try {
       await this.downloadScaffoldsRepo(scaffoldUrl)
       await this.extractScaffoldIfExists(flagScaffold, directoryName)

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -75,7 +75,6 @@ export default class New extends Command {
     })
   }
 
-  // Added optional "authorURL param to object"
   modifyManifest (directoryName: string, appName: string, authorName: string, authorEmail: string, flagScaffold: string, authorURL?: string) {
     const manifestPath: ManifestPath = {
       basic: path.join(process.cwd(), directoryName),

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -103,12 +103,12 @@ export default class New extends Command {
     const directoryName = flags.path || await CliUx.ux.prompt('Enter a directory name to save the new app (will create the dir if it does not exist)')
     const authorName = flags.authorName || await CliUx.ux.prompt('Enter this app authors name')
     let authorEmail = flags.authorEmail || await CliUx.ux.prompt('Enter this app authors email')
-    
+
     while (!this.EMAIL_REGEX.test(authorEmail)) {
       console.log(chalk.red('Invalid email, please try again'))
       authorEmail = flags.authorEmail || await CliUx.ux.prompt('Enter this app authors email')
     }
-    // Prompt user for authorURL
+
     let authorURL = flags.authorURL || await CliUx.ux.prompt('Enter this apps URL (Optional)', { required: false })
     
     while (authorURL.trim() && !this.URL_REGEX.test(authorURL)) {
@@ -128,6 +128,5 @@ export default class New extends Command {
 
     this.modifyManifest(directoryName, appName, authorName, authorEmail, flagScaffold, authorURL)
     console.log(chalk.green(`Successfully created new project ${directoryName}`))
-
   }
 }

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -7,7 +7,7 @@ import * as fsExtra from 'fs-extra'
 import * as https from 'https'
 import * as path from 'path'
 import * as AdmZip from 'adm-zip'
-import * as chalk from 'chalk' // import chalk from 'chalk' does not give error for me, neither does chalk.default.colour(cmd)
+import * as chalk from 'chalk' 
 import { CLIError } from '@oclif/core/lib/errors'
 
 export default class New extends Command {

--- a/packages/zcli-apps/tests/functional/new.test.ts
+++ b/packages/zcli-apps/tests/functional/new.test.ts
@@ -14,40 +14,6 @@ describe('apps new', () => {
   const dirPath = path.join(process.cwd(), dirName)
   let authorURL = 'https://test.com'
 
-  describe('valid authorURL inputs', () => {
-    test.it('valid authorURLs were accepted', async () => {
-      let authorURLTests: string[] = ['', ' ', '    ', 'https://t.test.com/a/b/c', 'test.com' ]
-      for(var i=1; i<authorURLTests.length; i++){
-        before(async () => {
-          await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURLTests[i]])
-        })
-        after(async () => {
-          await cleanDirectory(dirPath)
-        })
-      }
-    }) 
-  })
-
-  describe('manifest params', () => {
-      before(async () => {
-        await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', '\x0D'])
-      })
-  
-      afterEach(async () => {
-        await cleanDirectory(dirPath)
-      })
-  
-      test.it('authorURL field is not populated if user skips input ', async () => {
-        const manifestPath = path.join(process.cwd(), dirName, 'manifest.json')
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
-  
-        console.log('' + manifest.author.url + '' + " : URL ")
-
-          expect(manifest.author.url).to.eq(undefined)
-      })
-  })
-
-
   describe('--scaffold', () => {
     before(async () => {
       await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURL])
@@ -125,5 +91,35 @@ describe('apps new', () => {
       expect(manifest.author.email).to.eq(authorEmail)
       expect(manifest.author.url).to.eq(authorURL)
     })
+  })
+
+  describe('valid authorURL inputs', () => {
+    test.it('valid authorURLs were accepted', async () => {
+      let authorURLTests: string[] = ['', ' ', '    ', 'https://t.test.com/a/b/c', 'test.com' ]
+      for(var i=1; i<authorURLTests.length; i++){
+        before(async () => {
+          await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURLTests[i]])
+        })
+        after(async () => {
+          await cleanDirectory(dirPath)
+        })
+      }
+    }) 
+  })
+
+  describe('authorURL correctly populated in manifest', () => {
+      test.it('authorURL field is not populated if user skips input ', async () => {
+        before(async () => {
+          await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', '\x0D'])
+        })
+    
+        afterEach(async () => {
+          await cleanDirectory(dirPath)
+        })
+        const manifestPath = path.join(process.cwd(), dirName, 'manifest.json')
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+          expect(manifest.author.url).to.eq(undefined)
+      })
   })
 })

--- a/packages/zcli-apps/tests/functional/new.test.ts
+++ b/packages/zcli-apps/tests/functional/new.test.ts
@@ -3,6 +3,8 @@ import NewCommand from '../../src/commands/apps/new'
 import { cleanDirectory } from '../../src/utils/fileUtils'
 import * as path from 'path'
 import * as fs from 'fs'
+import { env } from 'process'
+import { url } from 'inspector'
 
 describe('apps new', () => {
   const dirName = 'myDir'
@@ -10,10 +12,45 @@ describe('apps new', () => {
   const authorEmail = 'test@email.com'
   const appName = 'testName'
   const dirPath = path.join(process.cwd(), dirName)
+  let authorURL = 'https://test.com'
+
+  describe('valid authorURL inputs', () => {
+    test.it('valid authorURLs were accepted', async () => {
+      let authorURLTests: string[] = ['', ' ', '    ', 'https://t.test.com/a/b/c', 'test.com' ]
+      for(var i=1; i<authorURLTests.length; i++){
+        before(async () => {
+          await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURLTests[i]])
+        })
+        after(async () => {
+          await cleanDirectory(dirPath)
+        })
+      }
+    }) 
+  })
+
+  describe('manifest params', () => {
+      before(async () => {
+        await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', '\x0D'])
+      })
+  
+      afterEach(async () => {
+        await cleanDirectory(dirPath)
+      })
+  
+      test.it('authorURL field is not populated if user skips input ', async () => {
+        const manifestPath = path.join(process.cwd(), dirName, 'manifest.json')
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  
+        console.log('' + manifest.author.url + '' + " : URL ")
+
+          expect(manifest.author.url).to.eq(undefined)
+      })
+  })
+
 
   describe('--scaffold', () => {
     before(async () => {
-      await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName])
+      await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURL])
     })
 
     after(async () => {
@@ -38,7 +75,7 @@ describe('apps new', () => {
 
   describe('--scaffold=basic', () => {
     before(async () => {
-      await NewCommand.run(['--scaffold', 'basic', '--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName])
+      await NewCommand.run(['--scaffold', 'basic', '--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURL])
     })
 
     after(async () => {
@@ -57,7 +94,9 @@ describe('apps new', () => {
       expect(manifest.name).to.eq(appName)
       expect(manifest.author.name).to.eq(authorName)
       expect(manifest.author.email).to.eq(authorEmail)
+      expect(manifest.author.url).to.eq(authorURL)
     })
+
   })
 
   describe('--scaffold=react', () => {
@@ -65,7 +104,7 @@ describe('apps new', () => {
     const dirPath = path.join(process.cwd(), dirName)
 
     before(async () => {
-      await NewCommand.run(['--scaffold', 'react', '--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName])
+      await NewCommand.run(['--scaffold', 'react', '--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURL])
     })
 
     after(async () => {
@@ -84,6 +123,7 @@ describe('apps new', () => {
       expect(manifest.name).to.eq(appName)
       expect(manifest.author.name).to.eq(authorName)
       expect(manifest.author.email).to.eq(authorEmail)
+      expect(manifest.author.url).to.eq(authorURL)
     })
   })
 })

--- a/packages/zcli-apps/tests/functional/new.test.ts
+++ b/packages/zcli-apps/tests/functional/new.test.ts
@@ -3,8 +3,6 @@ import NewCommand from '../../src/commands/apps/new'
 import { cleanDirectory } from '../../src/utils/fileUtils'
 import * as path from 'path'
 import * as fs from 'fs'
-import { env } from 'process'
-import { url } from 'inspector'
 
 describe('apps new', () => {
   const dirName = 'myDir'
@@ -62,7 +60,6 @@ describe('apps new', () => {
       expect(manifest.author.email).to.eq(authorEmail)
       expect(manifest.author.url).to.eq(authorURL)
     })
-
   })
 
   describe('--scaffold=react', () => {
@@ -93,33 +90,19 @@ describe('apps new', () => {
     })
   })
 
-  describe('valid authorURL inputs', () => {
-    test.it('valid authorURLs were accepted', async () => {
-      let authorURLTests: string[] = ['', ' ', '    ', 'https://t.test.com/a/b/c', 'test.com' ]
-      for(var i=1; i<authorURLTests.length; i++){
-        before(async () => {
-          await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', authorURLTests[i]])
-        })
-        after(async () => {
-          await cleanDirectory(dirPath)
-        })
-      }
-    }) 
-  })
-
   describe('authorURL correctly populated in manifest', () => {
-      test.it('authorURL field is not populated if user skips input ', async () => {
-        before(async () => {
-          await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', '\x0D'])
-        })
-    
-        afterEach(async () => {
-          await cleanDirectory(dirPath)
-        })
-        const manifestPath = path.join(process.cwd(), dirName, 'manifest.json')
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    before(async () => {
+      await NewCommand.run(['--path', dirName, '--authorName', authorName, '--authorEmail', authorEmail, '--appName', appName, '--authorURL', '\x0D'])
+    })
 
-          expect(manifest.author.url).to.eq(undefined)
-      })
+    afterEach(async () => {
+      await cleanDirectory(dirPath)
+    })
+    test.it('authorURL field is not populated if user skips input ', async () => {
+      const manifestPath = path.join(process.cwd(), dirName, 'manifest.json')
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+      expect(manifest.author.url).to.eq(undefined)
+    })
   })
 })

--- a/packages/zcli-apps/tests/functional/new.test.ts
+++ b/packages/zcli-apps/tests/functional/new.test.ts
@@ -10,7 +10,7 @@ describe('apps new', () => {
   const authorEmail = 'test@email.com'
   const appName = 'testName'
   const dirPath = path.join(process.cwd(), dirName)
-  let authorURL = 'https://test.com'
+  const authorURL = 'https://test.com'
 
   describe('--scaffold', () => {
     before(async () => {


### PR DESCRIPTION
Added AuthorURL prompt to ZCLI generated app
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
User is prompted to provide optional authorURL field on zcli apps:new

If user enters invalid URL, they are asked to try again or skip (enter)

If user provides valid URL, author.url will be populated in manifest.json, 

If user skips, manifest will not contain an author.url parameter

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned change-log if the PR is
     merged. -->

## Detail

When user enters whitespaces and then skips, manifest will not contain an author.url parameter

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Risks

Low risk as far as I can tell, but perhaps removing authorURL parameter will break something down the line.. not too sure will need feedback here. 
