### PR TITLE
[VEG-1574] Support sending notifications to unpublished apps in ZCLI

### DIFF
--- a/packages/zcli-apps/src/lib/buildAppJSON.test.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.test.ts
@@ -308,6 +308,48 @@ describe('buildAppJSON', () => {
       })
     })
 
+  describe('for non private apps', () => {
+    test
+      .stub(appPath, 'validateAppPath', () => {}) // eslint-disable-line @typescript-eslint/no-empty-function
+      .stub(manifest, 'getManifestFile', () => manifestOutputNoParams)
+      .stub(uuid, 'uuidV4', () => mockId)
+      .stub(buildAppJSON, 'getLocationIcons', () => { return multiProductLocationIcons })
+      .it('should set appID to zero', async () => {
+        const appJSON = await buildAppJSON.buildAppJSON(['./app1'], 1234)
+
+        expect(appJSON).to.deep.include({
+          apps: [
+            {
+              asset_url_prefix: 'http://localhost:1234/0/assets/',
+              default_locale: 'en',
+              framework_version: '2.0',
+              locations: multiProductLocations,
+              name: 'app 1',
+              id: '0',
+              signed_urls: false,
+              single_install: true,
+              version: undefined
+            }
+          ],
+          installations: [
+            {
+              app_id: '0',
+              collapsible: true,
+              enabled: true,
+              id: mockId,
+              name: 'app 1',
+              plan: undefined,
+              requirements: [],
+              settings: [{
+                title: 'app 1'
+              }],
+              updated_at: '2020-01-01T00:00:00.000Z'
+            }
+          ]
+        })
+      })
+  })
+
   describe('with no params attribute on manifest file', () => {
     test
       .stub(appPath, 'validateAppPath', () => {}) // eslint-disable-line @typescript-eslint/no-empty-function

--- a/packages/zcli-apps/src/lib/buildAppJSON.ts
+++ b/packages/zcli-apps/src/lib/buildAppJSON.ts
@@ -135,7 +135,7 @@ export const buildAppJSON = async (appPaths: string[], port: number): Promise<Ap
     const manifest = getManifestFile(appPath)
     const zcliConfigFile = getAllConfigs(appPath) || {}
 
-    const appId = zcliConfigFile.app_id?.toString() || uuidV4()
+    const appId = zcliConfigFile.app_id?.toString() || '0'
     const configParams = zcliConfigFile.parameters || {} // if there are no parameters in the config, just attach an empty object
 
     const appSettings = await getAppSettings(manifest, configParams)


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
After running the command zcli apps:server, developers can use the [Send Notification to App API](https://developer.zendesk.com/api-reference/ticketing/apps/apps/#send-notification-to-app) to send messages to unpublished apps by setting the app_id parameter to 0 in the same way they can with Zendesk App Tools (ZAT)

## Detail

JIRA: https://zendesk.atlassian.net/browse/VEG-1574

Here is a recording of **refreshing** the non published test app running on ZCLI  via the notify endpoint

https://share.getcloudapp.com/L1u6ojGk

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
