### PR TITLE
Prevent publishing to internal repo or from non-`master` branches

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit when any command fails
 set -e
+
+if [[ "$(yarn config get @zendesk:registry)" == *'jfrog'* ]]; then
+    # https://github.com/yarnpkg/yarn/issues/5310
+    printf 'Please remove Artifactory configurations from ~/.npmrc first\n'
+    exit 1
+fi
 
 echo '🔄 Generate tag, update docs and changelog'
 yarn install

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,6 +9,15 @@ if [[ "$(yarn config get @zendesk:registry)" == *'jfrog'* ]]; then
     exit 1
 fi
 
+if [[ "$(git branch --show-current)" != "master" ]]; then
+    printf 'Your are not on master branch at the moment. Really continue? [y/n] '
+    read -n1 -r; printf '\n'
+    if [[ "$REPLY" != 'y' ]]; then
+        printf 'Aborted\n'
+        exit 0
+    fi
+fi
+
 echo '🔄 Generate tag, update docs and changelog'
 yarn install
 


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
may populate the commit body and versioned changelog if the PR is
merged. -->
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`0dd37eb`](https://github.com/zendesk/zcli/pull/150/commits/0dd37ebbab942e8b0a062f9db2ec08239a692c37) chore: Prevent publishing to internal repository

Since we use yarn [1], it seems due to [2] it always respects our global
configuration and publishes @zendesk/ packages to our internal
repository despite having [3].

So let's do a check before publishing.

[1] https://github.com/zendesk/zcli/blob/011cbf414882bb8c15ba1a4913fe6cef1ebe29ed/lerna.json#L23
[2] https://github.com/yarnpkg/yarn/issues/5310
[3] https://github.com/zendesk/zcli/blob/011cbf414882bb8c15ba1a4913fe6cef1ebe29ed/lerna.json#L16-L18


### [`70d64de`](https://github.com/zendesk/zcli/pull/150/commits/70d64de23815ab20b41aa97a76948d2bdb372de8) chore: Ask if want to publish if not on master

Release tags should be on master branch only (although we are still on
beta). So ask user if they really want to publish if current branch is
not master.


<!-- === GH HISTORY FENCE === -->


## Checklist

- [ ] :guardsman: includes new unit and functional tests
