### PR TITLE
[VEG-BAU]Check if logged to npm before publish

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,6 +9,11 @@ if [[ "$(yarn config get @zendesk:registry)" == *'jfrog'* ]]; then
     exit 1
 fi
 
+if ! npm whoami &> /dev/null; then
+  printf 'Please make sure you are logged into NPM\n'
+  exit 1
+fi
+
 if [[ "$(git branch --show-current)" != "master" ]]; then
     printf 'Your are not on master branch at the moment. Really continue? [y/n] '
     read -n1 -r; printf '\n'


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This is a tiny PR to check if the user is logged into NPM before running the release script. This is to prevent the possibility of publishing directly into artifactory in the event the user isn't logged into NPM
If we directly publish to artifactory it will mess up our mirrored setup and we have to ask packaging team to clean up.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
