### PR TITLE
Migrate Actions away from Node.js 12; set up `gh-ph`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,15 @@
      may populate the commit body and versioned changelog if the PR is
      merged. -->
 
+<!-- === GH HISTORY FORMAT FENCE === --> <!--
+### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
+--> <!-- === GH HISTORY FORMAT FENCE === -->
+<!-- === GH HISTORY FENCE === -->
+Do NOT write here! This section will be filled in by GitHub Action
+automatically. If you don't want this, either remove the markers or write
+outside the fences.
+<!-- === GH HISTORY FENCE === -->
+
 ## Detail
 
 <!-- supporting details; screen shot, code, etc. -->

--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -1,0 +1,19 @@
+name: Pull request history
+
+on:
+  pull_request:
+
+jobs:
+  gh-ph:
+    name: Add commit history to pull request description
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zendesk/checkout@v3
+        with:
+          fetch-depth: 100
+      - run: |
+          git remote set-branches origin '*'
+          git fetch --depth 100
+      - uses: zendesk/gh-ph@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,59 +2,59 @@ name: Test
 
 on:
   push:
-    branches: master
+    branches:
+      - master
   pull_request:
-    branches: master
 
 jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: zendesk/checkout@v2
-    - name: Use Node.js
-      uses: zendesk/setup-node@v2.1.2
-      with:
-        node-version: '14.x'
-    - run: yarn install
-    - run: yarn lint
-    - run: yarn test
-    - run: yarn test:functional
-    - run: yarn dev
-    - run: yarn type:check
-      env:
-        CI: true
+      - uses: zendesk/checkout@v3
+      - name: Use Node.js
+        uses: zendesk/setup-node@v3
+        with:
+          node-version: "14.x"
+      - run: yarn install
+      - run: yarn lint
+      - run: yarn test
+      - run: yarn test:functional
+      - run: yarn dev
+      - run: yarn type:check
+        env:
+          CI: true
 
   build-mac:
     runs-on: macos-latest
     steps:
-    - uses: zendesk/checkout@v2
-    - name: Use Node.js
-      uses: zendesk/setup-node@v2.1.2
-      with:
-        node-version: '14.x'
-    - run: yarn install
-    - run: yarn lint
-    - run: yarn git:check
-    - run: yarn test
-    - run: yarn test:functional
-    - run: yarn dev
-    - run: yarn type:check
-      env:
-        CI: true
+      - uses: zendesk/checkout@v3
+      - name: Use Node.js
+        uses: zendesk/setup-node@v3
+        with:
+          node-version: "14.x"
+      - run: yarn install
+      - run: yarn lint
+      - run: yarn git:check
+      - run: yarn test
+      - run: yarn test:functional
+      - run: yarn dev
+      - run: yarn type:check
+        env:
+          CI: true
 
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: zendesk/checkout@v2
-    - name: Use Node.js
-      uses: zendesk/setup-node@v2.1.2
-      with:
-        node-version: '14.x'
-    - run: yarn install
-    - run: yarn lint
-    - run: yarn test
-    - run: yarn test:functional
-    - run: yarn dev
-    - run: yarn type:check
-      env:
-        CI: true
+      - uses: zendesk/checkout@v3
+      - name: Use Node.js
+        uses: zendesk/setup-node@v3
+        with:
+          node-version: "14.x"
+      - run: yarn install
+      - run: yarn lint
+      - run: yarn test
+      - run: yarn test:functional
+      - run: yarn dev
+      - run: yarn type:check
+        env:
+          CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,18 @@ jobs:
         uses: zendesk/setup-node@v3
         with:
           node-version: "${{ matrix.node-version }}"
+          cache: "yarn"
+      - uses: zendesk/cache@v3
+        with:
+          path: |
+            ./node_modules/
+            ./packages/zcli/node_modules/
+            ./packages/zcli-core/node_modules/
+            ./packages/zcli-apps/node_modules/
+          key: node-modules-${{ runner.os }}-${{ hashFiles('**/package.json') }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ hashFiles('**/package.json') }}-
+            node-modules-${{ runner.os }}-
       - run: yarn install
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,49 +7,21 @@ on:
   pull_request:
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build-and-check:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node-version: ["14.x"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: zendesk/checkout@v3
       - name: Use Node.js
         uses: zendesk/setup-node@v3
         with:
-          node-version: "14.x"
-      - run: yarn install
-      - run: yarn lint
-      - run: yarn test
-      - run: yarn test:functional
-      - run: yarn dev
-      - run: yarn type:check
-        env:
-          CI: true
-
-  build-mac:
-    runs-on: macos-latest
-    steps:
-      - uses: zendesk/checkout@v3
-      - name: Use Node.js
-        uses: zendesk/setup-node@v3
-        with:
-          node-version: "14.x"
-      - run: yarn install
-      - run: yarn lint
-      - run: yarn git:check
-      - run: yarn test
-      - run: yarn test:functional
-      - run: yarn dev
-      - run: yarn type:check
-        env:
-          CI: true
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: zendesk/checkout@v3
-      - name: Use Node.js
-        uses: zendesk/setup-node@v3
-        with:
-          node-version: "14.x"
+          node-version: "${{ matrix.node-version }}"
       - run: yarn install
       - run: yarn lint
       - run: yarn test


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`68d7098`](https://github.com/zendesk/zcli/pull/158/commits/68d709805092dd6f745a30663d6b880c294255fc) ci: Migrate GitHub Actions away from Node.js 12

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/


### [`093cc1e`](https://github.com/zendesk/zcli/pull/158/commits/093cc1eb20a5d07c96b8346ffeea781c89924385) ci: Set up gh-ph to fill in PR histories



### [`d132e59`](https://github.com/zendesk/zcli/pull/158/commits/d132e59f7d42f05eea14ecb45936b1c2b412b9da) ci: Use Actions matrix syntax



### [`1a32344`](https://github.com/zendesk/zcli/pull/158/commits/1a323440755547a39dac106dfec9ad7671befaf6) ci: Cache Node.js dependencies



<!-- === GH HISTORY FENCE === -->


## Checklist

- [ ] :guardsman: includes new unit and functional tests
