### PR TITLE
Remove bind and port flags - zcli:apps server

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -130,16 +130,14 @@ USAGE
 
 OPTIONS
   -h, --help       show CLI help
-  --bind=bind      [default: localhost] Bind apps server to a specific host
   --logs           Tail logs
-  --port=port      [default: 4567] Port for the http server to use
 
 EXAMPLES
   $ zcli apps:server ./repl-app2
   $ zcli apps:server ./repl-app2 ./knowledge-capture-app
 ```
 
-After server is running, add `?zcli_apps=true` to the end of your Zendesk URL to load from the locally served apps. `?zat=true` will *not* work with ZCLI.  
+After server is running, add `?zcli_apps=true` to the end of your Zendesk URL to load from the locally served apps. `?zat=true` will *not* work with ZCLI.
 
 ## `zcli apps:update APPDIRECTORIES`
 

--- a/packages/zcli-apps/src/commands/apps/server.ts
+++ b/packages/zcli-apps/src/commands/apps/server.ts
@@ -17,8 +17,6 @@ export default class Server extends Command {
 
   static flags = {
     help: Flags.help({ char: 'h' }),
-    bind: Flags.string({ default: 'localhost', description: 'Bind apps server to a specific host' }),
-    port: Flags.string({ default: '4567', description: 'Port for the http server to use' }),
     logs: Flags.boolean({ default: false, description: 'Tail logs' })
     // TODO: custom file is not supported for other commands,
     // lets come back to this in near future
@@ -38,8 +36,9 @@ export default class Server extends Command {
 
   async run () {
     const { flags } = await this.parse(Server)
-    const port = parseInt(flags.port)
-    const { logs: tailLogs, bind: host } = flags
+    const port = 4567
+    const host = 'localhost'
+    const { logs: tailLogs } = flags
     const { argv: appDirectories } = await this.parse(Server)
 
     const appPaths = getAppPaths(appDirectories)


### PR DESCRIPTION
## Description

This PR removes the bind and port flags from server.ts and sets the host and port variables with hardcoded default values. This removes the ability for the user to manually enter custom port values, as well as removing reference to these flags in the --help prompt. 

This PR also removes reference to the bind and port flags in the documentation at apps.md.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Do NOT write here! This section will be filled in by GitHub Action
automatically. If you don't want this, either remove the markers or write
outside the fences.
<!-- === GH HISTORY FENCE === -->

- [ ] :guardsman: includes new unit and functional tests
