### PR TITLE
fix: Pin all oclif dependencies to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@oclif/core": "^1.11.0",
-    "@oclif/test": "^2.1.0",
+    "@oclif/core": "=1.12.0",
+    "@oclif/test": "=2.1.0",
     "@types/chai": "^4",
     "@types/express": "^4.17.3",
     "@types/mocha": "^9.1.1",

--- a/packages/zcli-apps/package.json
+++ b/packages/zcli-apps/package.json
@@ -32,7 +32,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@oclif/test": "^2.1.0",
+    "@oclif/test": "=2.1.0",
     "@types/adm-zip": "^0.5.0",
     "@types/archiver": "^5.3.1",
     "@types/chai": "^4",

--- a/packages/zcli-core/package.json
+++ b/packages/zcli-core/package.json
@@ -23,7 +23,7 @@
     "keytar": "^7.9.0"
   },
   "dependencies": {
-    "@oclif/plugin-plugins": "~2.1.0",
+    "@oclif/plugin-plugins": "=2.1.12",
     "axios": "^0.27.2",
     "chalk": "^4.1.2",
     "fs-extra": "^10.1.0"

--- a/packages/zcli/package.json
+++ b/packages/zcli/package.json
@@ -11,11 +11,11 @@
     "zcli": "./bin/run"
   },
   "dependencies": {
-    "@oclif/plugin-autocomplete": "~1.3.0",
-    "@oclif/plugin-help": "~5.1.12",
-    "@oclif/plugin-not-found": "~2.3.1",
-    "@oclif/plugin-update": "~3.0.0",
-    "@oclif/plugin-warn-if-update-available": "~2.0.4",
+    "@oclif/plugin-autocomplete": "=1.3.10",
+    "@oclif/plugin-help": "=5.1.23",
+    "@oclif/plugin-not-found": "=2.3.16",
+    "@oclif/plugin-update": "=3.0.13",
+    "@oclif/plugin-warn-if-update-available": "=2.0.20",
     "@zendesk/zcli-apps": "^1.0.0-beta.28",
     "@zendesk/zcli-core": "^1.0.0-beta.29",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,7 +1185,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@^1.11.0", "@oclif/core@^1.3.1":
+"@oclif/core@=1.12.0", "@oclif/core@^1.3.1":
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-1.12.0.tgz#f438d12c6085580e3f7c43c73ccd6edc4b193862"
   integrity sha512-TR7k5EaekRH+TI1KxpxGda6DirGmUjVi+rz/RBtVxXTyGS446ZHRjlmogU7TIfTGLd1fdS0w0Eo8AHPjd3kh1w==
@@ -1258,7 +1258,7 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/plugin-autocomplete@~1.3.0":
+"@oclif/plugin-autocomplete@=1.3.10":
   version "1.3.10"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-autocomplete/-/plugin-autocomplete-1.3.10.tgz#3b6ff23ca03513f05b6719ddf51f01b35bd8bf69"
   integrity sha512-oQl7ZqXhXJUOH26mDPcqcMGmcdIoK/uQPSpUBrfLa1iaQ30slTs0T7KOzg+vwKuPqIIF1nTCPuH67lE8GvUPTw==
@@ -1268,14 +1268,14 @@
     debug "^4.3.4"
     fs-extra "^9.0.1"
 
-"@oclif/plugin-help@~5.1.12":
+"@oclif/plugin-help@=5.1.23":
   version "5.1.23"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-5.1.23.tgz#529b193b35436ef9374fd9ba4d065e19b73b6b5a"
   integrity sha512-8oyyu/yPz55Zhj0U58/YXGc51N65vOpVeqDalf5xby4T+VMo4naDVJMxcSpJF2YUTREXEfO2pcC0aA4PE5q8Ig==
   dependencies:
     "@oclif/core" "^1.24.0"
 
-"@oclif/plugin-not-found@~2.3.1":
+"@oclif/plugin-not-found@=2.3.16":
   version "2.3.16"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-not-found/-/plugin-not-found-2.3.16.tgz#3505cc1c34413d50750b05bd889e93d35f50bde9"
   integrity sha512-MKKRVMoSHbcw9WPDQ47XIsQKRzPklrMRt6uTEVwOFSHXtQ7uopCyf52riMxy0pI7Jq9zma3XuyB56JxmRhYCEw==
@@ -1285,7 +1285,7 @@
     fast-levenshtein "^3.0.0"
     lodash "^4.17.21"
 
-"@oclif/plugin-plugins@~2.1.0":
+"@oclif/plugin-plugins@=2.1.12":
   version "2.1.12"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-plugins/-/plugin-plugins-2.1.12.tgz#1b2a8e08481b0691adca09714ceb44fb293cceb6"
   integrity sha512-vvste+qfmuAZVO+LEhJbBm7kLAtWCFFyfoAFCpe061i8KRnsl8/f0l+/VLAUWiYB3c5M518knIi/UfIvGPV/Ew==
@@ -1302,7 +1302,7 @@
     tslib "^2.4.1"
     yarn "^1.22.18"
 
-"@oclif/plugin-update@~3.0.0":
+"@oclif/plugin-update@=3.0.13":
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-update/-/plugin-update-3.0.13.tgz#a83c6d11cde7f020e6eb2f7b4fad127927da1a2b"
   integrity sha512-qr3Y2meL7DQpSTjaXmQgfHuLRWM+/ZsMFm6HirqdiV3BtWNxvtu/hicySvSgmE73O5Wh0G0H3RHmPdoddhbr2A==
@@ -1320,7 +1320,7 @@
     semver "^7.3.8"
     tar-fs "^2.1.1"
 
-"@oclif/plugin-warn-if-update-available@~2.0.4":
+"@oclif/plugin-warn-if-update-available@=2.0.20":
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.0.20.tgz#095f6df60e367d620ff8836d61dd752e08865205"
   integrity sha512-vbPeT6dIGy28yZZ1ey/+c47iBUTNwnrs9mOEEgek9ZWtx0OszVWlP5XYiaoypnStbkXzVA96Bty8aKdi2zhOaA==
@@ -1343,7 +1343,7 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-3.0.4.tgz#663db0ecaf23f3184e7f01886ed578060e4a7f1c"
   integrity sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==
 
-"@oclif/test@^2.1.0":
+"@oclif/test@=2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@oclif/test/-/test-2.1.0.tgz#e5a0ba619c890770782e48c82d18f5921e2d2b9f"
   integrity sha512-o+JTv3k28aMUxywJUlJY1/DORLqumoZFRII492phOmtXM16rD6Luy3z1qinT4BvEtPj2BzOPd2whr/VdYszaYw==


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`622553f`](https://github.com/zendesk/zcli/pull/162/commits/622553fa07625d79cbd67537253431c42841b1c0) fix: Pin all oclif dependencies to exact versions

As much as we want to allow customers to get latest patches as soon as
possible, oclif on the other hand keeps breaking the Semantic Versioning
2.0.0 [1] contract, where breaking changes must lead to major version
bumps.

After fixing last breakage in [2][3] by pinning minor versions,
oclif/plugin-not-found also upgraded to oclif/core v2 [4] and this time
only patch version was bumped [5].

So being cautious this time and just pin all oclif dependencies to
exactly the same versions as those in the lock file.

[1] https://semver.org
[2] https://github.com/zendesk/zcli/pull/157
[3] https://github.com/zendesk/zcli/commit/3c73b5334e5604ba5c3ed40eb8eb76a758b3c0c3
[4] https://github.com/oclif/plugin-not-found/commit/b3176628b2dddd69c4419f8270fbb510231d3f8e
[5] https://github.com/oclif/plugin-not-found/releases/tag/2.3.17


<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

Reported at https://github.com/zendesk/zcli/issues/160

## Checklist

- [ ] :guardsman: includes new unit and functional tests
