### PR TITLE
Support for zcli themes:import

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -31,3 +31,28 @@ EXAMPLES
   $ zcli themes:preview ./copenhagen_theme --port=9999
   $ zcli themes:preview ./copenhagen_theme --no-livereload
 ```
+
+* [`zcli themes:import [THEMEDIRECTORY]`](#zcli-themesimport-themedirectory)
+
+## Configuration
+
+NOTE: import requires login so make sure to first run `zcli login -i`
+
+## `zcli themes:import [THEMEDIRECTORY]`
+
+imports a theme in your desired target account and brand
+
+```
+USAGE
+  $ zcli themes:import [THEMEDIRECTORY]
+
+ARGUMENTS
+  THEMEDIRECTORY  [default: .] theme path where manifest.json exists
+
+OPTIONS
+  --brandId       The id of the brand where the theme should be imported to
+
+EXAMPLES
+  $ zcli themes:import ./copenhagen_theme
+  $ zcli themes:import ./copenhagen_theme --brandId=123456789100
+```

--- a/packages/zcli-themes/package.json
+++ b/packages/zcli-themes/package.json
@@ -17,6 +17,7 @@
     "type:check": "tsc"
   },
   "dependencies": {
+    "@types/inquirer": "^8.0.0",
     "@types/ws": "^8.5.4",
     "axios": "^0.27.2",
     "chalk": "^4.1.2",
@@ -24,6 +25,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "glob": "^9.3.2",
+    "inquirer": "^8.0.0",
     "sass": "^1.60.0",
     "ws": "^8.13.0"
   },

--- a/packages/zcli-themes/src/commands/themes/import.ts
+++ b/packages/zcli-themes/src/commands/themes/import.ts
@@ -19,7 +19,8 @@ export default class Import extends Command {
   ]
 
   static examples = [
-    '$ zcli themes:import ./copenhagen_theme'
+    '$ zcli themes:import ./copenhagen_theme',
+    '$ zcli themes:import ./copenhagen_theme --brandId=123456789100'
   ]
 
   static strict = false

--- a/packages/zcli-themes/src/commands/themes/import.ts
+++ b/packages/zcli-themes/src/commands/themes/import.ts
@@ -1,0 +1,46 @@
+import { Command, Flags } from '@oclif/core'
+import * as path from 'path'
+import * as chalk from 'chalk'
+import createThemeImportJob from '../../lib/createThemeImportJob'
+import getBrandId from '../../lib/getBrandId'
+import createThemePackage from '../../lib/createThemePackage'
+import uploadThemePackage from '../../lib/uploadThemePackage'
+import pollJobStatus from '../../lib/pollJobStatus'
+
+export default class Import extends Command {
+  static description = 'import a theme'
+
+  static flags = {
+    brandId: Flags.string({ description: 'The id of the brand where the theme should be imported to' })
+  }
+
+  static args = [
+    { name: 'themeDirectory', required: true, default: '.' }
+  ]
+
+  static examples = [
+    '$ zcli themes:import ./copenhagen_theme'
+  ]
+
+  static strict = false
+
+  async run () {
+    let { flags: { brandId }, argv: [themeDirectory] } = await this.parse(Import)
+    const themePath = path.resolve(themeDirectory)
+
+    brandId = brandId || await getBrandId()
+
+    const job = await createThemeImportJob(brandId)
+    const { readStream, removePackage } = await createThemePackage(themePath)
+
+    try {
+      await uploadThemePackage(job, readStream)
+    } finally {
+      removePackage()
+    }
+
+    await pollJobStatus(themePath, job.id)
+
+    this.log(chalk.green('Theme imported successfully'), `theme ID: ${job.data.theme_id}`)
+  }
+}

--- a/packages/zcli-themes/src/lib/createThemeImportJob.test.ts
+++ b/packages/zcli-themes/src/lib/createThemeImportJob.test.ts
@@ -1,0 +1,59 @@
+import * as sinon from 'sinon'
+import { expect } from '@oclif/test'
+import * as axios from 'axios'
+import { request } from '@zendesk/zcli-core'
+import createThemeImportJob from './createThemeImportJob'
+import * as chalk from 'chalk'
+import * as errors from '@oclif/core/lib/errors'
+
+describe('createThemeImportJob', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('calls the jobs/themes/imports endpoint with the correct payload and returns the job', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const job = {
+      id: '9999',
+      status: 'pending',
+      data: {}
+    }
+
+    requestStub.returns(Promise.resolve({ data: { job } }) as axios.AxiosPromise)
+
+    expect(await createThemeImportJob('1234')).to.equal(job)
+
+    expect(requestStub.calledWith('/api/v2/guide/theming/jobs/themes/imports', sinon.match({
+      method: 'POST',
+      data: {
+        job: {
+          attributes: {
+            brand_id: '1234',
+            format: 'zip'
+          }
+        }
+      }
+    }))).to.equal(true)
+  })
+
+  it('errors when creation fails', async () => {
+    const errorStub = sinon.stub(errors, 'error').callThrough()
+
+    sinon.stub(request, 'requestAPI').throws({
+      response: {
+        data: {
+          errors: [{
+            code: 'TooManyThemes',
+            title: 'Maximum number of allowed themes reached'
+          }]
+        }
+      }
+    })
+
+    try {
+      await createThemeImportJob('1234')
+    } catch {
+      expect(errorStub.calledWith(`${chalk.bold('TooManyThemes')} - Maximum number of allowed themes reached`)).to.equal(true)
+    }
+  })
+})

--- a/packages/zcli-themes/src/lib/createThemeImportJob.ts
+++ b/packages/zcli-themes/src/lib/createThemeImportJob.ts
@@ -1,0 +1,35 @@
+import type { PendingJob } from '../types'
+import { CliUx } from '@oclif/core'
+import { request } from '@zendesk/zcli-core'
+import * as chalk from 'chalk'
+import * as axios from 'axios'
+import { CLIError, error } from '@oclif/core/lib/errors'
+
+export default async function createThemeImportJob (brandId: string): Promise<PendingJob> {
+  CliUx.ux.action.start('Creating theme import job')
+
+  try {
+    const { data: { job } } = await request.requestAPI('/api/v2/guide/theming/jobs/themes/imports', {
+      method: 'POST',
+      data: {
+        job: {
+          attributes: {
+            brand_id: brandId,
+            format: 'zip'
+          }
+        }
+      },
+      validateStatus: (status: number) => status === 202
+    })
+    CliUx.ux.action.stop('Ok')
+    return job
+  } catch (e) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errors = (e as any).response.data.errors
+    for (const { code, title } of errors) {
+      error(`${chalk.bold(code)} - ${title}`)
+    }
+
+    error(new CLIError(e as axios.AxiosError))
+  }
+}

--- a/packages/zcli-themes/src/lib/createThemeImportJob.ts
+++ b/packages/zcli-themes/src/lib/createThemeImportJob.ts
@@ -11,6 +11,9 @@ export default async function createThemeImportJob (brandId: string): Promise<Pe
   try {
     const { data: { job } } = await request.requestAPI('/api/v2/guide/theming/jobs/themes/imports', {
       method: 'POST',
+      headers: {
+        'X-Zendesk-Request-Originator': 'zcli themes:import'
+      },
       data: {
         job: {
           attributes: {

--- a/packages/zcli-themes/src/lib/createThemePackage.test.ts
+++ b/packages/zcli-themes/src/lib/createThemePackage.test.ts
@@ -1,0 +1,36 @@
+import * as sinon from 'sinon'
+import { expect } from '@oclif/test'
+import * as fs from 'fs'
+import * as createThemePackage from './createThemePackage'
+
+describe('createThemePackage', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('returns an object containing a readStream and a removePackage method', async () => {
+    const writeStreamStub = sinon.createStubInstance(fs.WriteStream)
+    sinon.stub(fs, 'createWriteStream').returns(writeStreamStub)
+
+    const readStreamStub = sinon.createStubInstance(fs.ReadStream)
+    sinon.stub(fs, 'createReadStream').returns(readStreamStub)
+
+    const unlinkSyncStub = sinon.stub(fs, 'unlinkSync')
+
+    const createZipArchiveStub = sinon.stub(createThemePackage, 'createZipArchive')
+
+    createZipArchiveStub.returns({
+      pipe: sinon.stub(),
+      directory: sinon.stub(),
+      file: sinon.stub(),
+      finalize: sinon.stub()
+    } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const { readStream, removePackage } = await createThemePackage.default('theme/path')
+
+    expect(readStream).to.instanceOf(fs.ReadStream)
+
+    removePackage()
+    expect(unlinkSyncStub.called).to.equal(true)
+  })
+})

--- a/packages/zcli-themes/src/lib/createThemePackage.ts
+++ b/packages/zcli-themes/src/lib/createThemePackage.ts
@@ -1,0 +1,40 @@
+import { CliUx } from '@oclif/core'
+import * as fs from 'fs'
+import * as archiver from 'archiver'
+
+type CreateThemePackage = {
+  readStream: fs.ReadStream,
+  removePackage: () => void
+}
+
+export const createZipArchive = () => archiver('zip')
+
+export default async function createThemePackage (themePath: string): Promise<CreateThemePackage> {
+  CliUx.ux.action.start('Creating theme package')
+
+  const dateTimeFileName = new Date().toISOString().replace(/[^0-9]/g, '')
+  const pkgName = `theme-${dateTimeFileName}`
+  const pkgPath = `${themePath}/${pkgName}.zip`
+  const output = fs.createWriteStream(pkgPath)
+  const archive = createZipArchive()
+
+  archive.pipe(output)
+
+  archive.directory(`${themePath}/assets`, `${pkgName}/assets`)
+  archive.directory(`${themePath}/settings`, `${pkgName}/settings`)
+  archive.directory(`${themePath}/templates`, `${pkgName}/templates`)
+  archive.directory(`${themePath}/translations`, `${pkgName}/translations`)
+  archive.file(`${themePath}/manifest.json`, { name: `${pkgName}/manifest.json` })
+  archive.file(`${themePath}/script.js`, { name: `${pkgName}/script.js` })
+  archive.file(`${themePath}/style.css`, { name: `${pkgName}/style.css` })
+  archive.file(`${themePath}/thumbnail.png`, { name: `${pkgName}/thumbnail.png` })
+
+  await archive.finalize()
+
+  CliUx.ux.action.stop('Ok')
+
+  return {
+    readStream: fs.createReadStream(pkgPath),
+    removePackage: () => fs.unlinkSync(pkgPath)
+  }
+}

--- a/packages/zcli-themes/src/lib/getBrandId.test.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.test.ts
@@ -4,6 +4,7 @@ import * as axios from 'axios'
 import { request } from '@zendesk/zcli-core'
 import getBrandId from './getBrandId'
 import * as inquirer from 'inquirer'
+import * as errors from '@oclif/core/lib/errors'
 
 describe('getBrandId', () => {
   beforeEach(() => {
@@ -44,5 +45,18 @@ describe('getBrandId', () => {
     const brandId = await getBrandId()
 
     expect(brandId).to.equal('2222')
+  })
+
+  it('handles failure when requesting brands', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const errorStub = sinon.stub(errors, 'error')
+
+    requestStub.throws()
+
+    try {
+      await getBrandId()
+    } catch {
+      expect(errorStub.calledWith('Failed to retrieve brands')).to.equal(true)
+    }
   })
 })

--- a/packages/zcli-themes/src/lib/getBrandId.test.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.test.ts
@@ -1,0 +1,48 @@
+import * as sinon from 'sinon'
+import { expect } from '@oclif/test'
+import * as axios from 'axios'
+import { request } from '@zendesk/zcli-core'
+import getBrandId from './getBrandId'
+import * as inquirer from 'inquirer'
+
+describe('getBrandId', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('returns the brandId of the first brand when there\' only one brand', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+
+    requestStub.returns(Promise.resolve({
+      data: {
+        brands: [{
+          id: '1234'
+        }]
+      }
+    }) as axios.AxiosPromise)
+
+    const brandId = await getBrandId()
+
+    expect(brandId).to.equal('1234')
+  })
+
+  it('prompts the user when there are multiple brands', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const promptStub = sinon.stub(inquirer, 'prompt')
+
+    requestStub.returns(Promise.resolve({
+      data: {
+        brands: [
+          { id: '1111', name: 'Brand 1' },
+          { id: '2222', name: 'Brand 2' }
+        ]
+      }
+    }) as axios.AxiosPromise)
+
+    promptStub.returns(Promise.resolve({ brandId: '2222' }))
+
+    const brandId = await getBrandId()
+
+    expect(brandId).to.equal('2222')
+  })
+})

--- a/packages/zcli-themes/src/lib/getBrandId.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.ts
@@ -1,0 +1,20 @@
+import type { Brand } from '../types'
+import { request } from '@zendesk/zcli-core'
+import * as inquirer from 'inquirer'
+
+export default async function getBrandId (): Promise<string> {
+  const { data: { brands } } = await request.requestAPI('/api/v2/brands.json')
+  if (brands.length === 1) return brands[0].id
+
+  const { brandId } = await inquirer.prompt({
+    type: 'list',
+    name: 'brandId',
+    message: 'What brand should the theme be imported to?',
+    choices: brands.map((brand: Brand) => ({
+      name: brand.name,
+      value: brand.id.toString()
+    }))
+  })
+
+  return brandId
+}

--- a/packages/zcli-themes/src/lib/getBrandId.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.ts
@@ -1,20 +1,30 @@
+import { error } from '@oclif/core/lib/errors'
 import type { Brand } from '../types'
 import { request } from '@zendesk/zcli-core'
 import * as inquirer from 'inquirer'
 
 export default async function getBrandId (): Promise<string> {
-  const { data: { brands } } = await request.requestAPI('/api/v2/brands.json')
-  if (brands.length === 1) return brands[0].id
+  try {
+    const { data: { brands } } = await request.requestAPI('/api/v2/brands.json', {
+      validateStatus: (status: number) => status === 200
+    })
 
-  const { brandId } = await inquirer.prompt({
-    type: 'list',
-    name: 'brandId',
-    message: 'What brand should the theme be imported to?',
-    choices: brands.map((brand: Brand) => ({
-      name: brand.name,
-      value: brand.id.toString()
-    }))
-  })
+    if (brands.length === 1) {
+      return brands[0].id
+    }
 
-  return brandId
+    const { brandId } = await inquirer.prompt({
+      type: 'list',
+      name: 'brandId',
+      message: 'What brand should the theme be imported to?',
+      choices: brands.map((brand: Brand) => ({
+        name: brand.name,
+        value: brand.id.toString()
+      }))
+    })
+
+    return brandId
+  } catch {
+    error('Failed to retrieve brands')
+  }
 }

--- a/packages/zcli-themes/src/lib/pollJobStatus.test.ts
+++ b/packages/zcli-themes/src/lib/pollJobStatus.test.ts
@@ -1,0 +1,111 @@
+import * as sinon from 'sinon'
+import { expect } from '@oclif/test'
+import * as axios from 'axios'
+import { request } from '@zendesk/zcli-core'
+import pollJobStatus from './pollJobStatus'
+import * as chalk from 'chalk'
+import * as errors from '@oclif/core/lib/errors'
+
+describe('pollJobStatus', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('polls the jobs/{jobId} endpoint until the job is completed', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+
+    requestStub
+      .onFirstCall()
+      .returns(Promise.resolve({ data: { job: { status: 'pending' } } }) as axios.AxiosPromise)
+      .onSecondCall()
+      .returns(Promise.resolve({ data: { job: { status: 'pending' } } }) as axios.AxiosPromise)
+      .onThirdCall()
+      .returns(Promise.resolve({ data: { job: { status: 'completed', theme_id: '1234' } } }) as axios.AxiosPromise)
+
+    await pollJobStatus('theme/path', '9999', 10)
+
+    expect(requestStub.calledWith('/api/v2/guide/theming/jobs/9999')).to.equal(true)
+    expect(requestStub.callCount).to.equal(3)
+  })
+
+  it('times out after the specified number of retries', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const errorStub = sinon.stub(errors, 'error')
+
+    requestStub
+      .onFirstCall()
+      .returns(Promise.resolve({ data: { job: { status: 'pending' } } }) as axios.AxiosPromise)
+      .onSecondCall()
+      .returns(Promise.resolve({ data: { job: { status: 'pending' } } }) as axios.AxiosPromise)
+      .onThirdCall()
+      .returns(Promise.resolve({ data: { job: { status: 'pending' } } }) as axios.AxiosPromise)
+
+    await pollJobStatus('theme/path', '9999', 10, 3)
+
+    expect(requestStub.callCount).to.equal(3)
+    expect(errorStub.calledWith('Import job timed out')).to.equal(true)
+  })
+
+  it('handles job errors', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const errorStub = sinon.stub(errors, 'error').callThrough()
+
+    requestStub
+      .onFirstCall()
+      .returns(Promise.resolve({ data: { job: { status: 'pending' } } }) as axios.AxiosPromise)
+      .onSecondCall()
+      .returns(Promise.resolve({
+        data: {
+          job: {
+            status: 'failed',
+            errors: [
+              {
+                message: 'Template(s) with syntax error(s)',
+                code: 'InvalidTemplates',
+                meta: {
+                  'templates/home_page.hbs': [
+                    {
+                      description: 'not possible to access `names` in `help_center.names`',
+                      line: 1,
+                      column: 45,
+                      length: 5
+                    },
+                    {
+                      description: "'categoriess' does not exist",
+                      line: 21,
+                      column: 16,
+                      length: 11
+                    }
+                  ],
+                  'templates/new_request_page.hbs': [
+                    {
+                      description: "'request_fosrm' does not exist",
+                      line: 22,
+                      column: 6,
+                      length: 10
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }) as axios.AxiosPromise)
+
+    try {
+      await pollJobStatus('theme/path', '9999', 10, 2)
+    } catch {
+      expect(requestStub.callCount).to.equal(2)
+      expect(errorStub.calledWithMatch('Template(s) with syntax error(s)')).to.equal(true)
+
+      expect(errorStub.calledWithMatch(`${chalk.bold('Validation error')} theme/path/templates/home_page.hbs:1:45`)).to.equal(true)
+      expect(errorStub.calledWithMatch('not possible to access `names` in `help_center.names`')).to.equal(true)
+
+      expect(errorStub.calledWithMatch(`${chalk.bold('Validation error')} theme/path/templates/home_page.hbs:21:16`)).to.equal(true)
+      expect(errorStub.calledWithMatch("'categoriess' does not exist")).to.equal(true)
+
+      expect(errorStub.calledWithMatch(`${chalk.bold('Validation error')} theme/path/templates/new_request_page.hbs:22:6`)).to.equal(true)
+      expect(errorStub.calledWithMatch("'request_fosrm' does not exist")).to.equal(true)
+    }
+  })
+})

--- a/packages/zcli-themes/src/lib/pollJobStatus.test.ts
+++ b/packages/zcli-themes/src/lib/pollJobStatus.test.ts
@@ -71,7 +71,7 @@ describe('pollJobStatus', () => {
                       length: 5
                     },
                     {
-                      description: "'categoriess' does not exist",
+                      description: "'articles' does not exist",
                       line: 21,
                       column: 16,
                       length: 11
@@ -79,7 +79,7 @@ describe('pollJobStatus', () => {
                   ],
                   'templates/new_request_page.hbs': [
                     {
-                      description: "'request_fosrm' does not exist",
+                      description: "'post_form' does not exist",
                       line: 22,
                       column: 6,
                       length: 10
@@ -102,10 +102,10 @@ describe('pollJobStatus', () => {
       expect(errorStub.calledWithMatch('not possible to access `names` in `help_center.names`')).to.equal(true)
 
       expect(errorStub.calledWithMatch(`${chalk.bold('Validation error')} theme/path/templates/home_page.hbs:21:16`)).to.equal(true)
-      expect(errorStub.calledWithMatch("'categoriess' does not exist")).to.equal(true)
+      expect(errorStub.calledWithMatch("'articles' does not exist")).to.equal(true)
 
       expect(errorStub.calledWithMatch(`${chalk.bold('Validation error')} theme/path/templates/new_request_page.hbs:22:6`)).to.equal(true)
-      expect(errorStub.calledWithMatch("'request_fosrm' does not exist")).to.equal(true)
+      expect(errorStub.calledWithMatch("'post_form' does not exist")).to.equal(true)
     }
   })
 })

--- a/packages/zcli-themes/src/lib/pollJobStatus.ts
+++ b/packages/zcli-themes/src/lib/pollJobStatus.ts
@@ -3,6 +3,7 @@ import { CliUx } from '@oclif/core'
 import { error } from '@oclif/core/lib/errors'
 import { request } from '@zendesk/zcli-core'
 import * as chalk from 'chalk'
+import validationErrorsToString from './validationErrorsToString'
 
 export default async function pollJobStatus (themePath: string, jobId: string, interval = 1000, retries = 10): Promise<void> {
   CliUx.ux.action.start('Polling job status')
@@ -51,16 +52,4 @@ function handleJobError (themePath: string, jobError: JobError): void {
   }
 
   error(`${title}\n${details}`)
-}
-
-export function validationErrorsToString (themePath: string, validationErrors: ValidationErrors): string {
-  let string = ''
-
-  for (const [template, errors] of Object.entries(validationErrors)) {
-    for (const { line, column, description } of errors) {
-      string += `\n${chalk.bold('Validation error')} ${themePath}/${template}${line && column ? `:${line}:${column}` : ''}\n ${description}\n`
-    }
-  }
-
-  return string
 }

--- a/packages/zcli-themes/src/lib/pollJobStatus.ts
+++ b/packages/zcli-themes/src/lib/pollJobStatus.ts
@@ -1,0 +1,66 @@
+import type { Job, JobError, ValidationErrors } from '../types'
+import { CliUx } from '@oclif/core'
+import { error } from '@oclif/core/lib/errors'
+import { request } from '@zendesk/zcli-core'
+import * as chalk from 'chalk'
+
+export default async function pollJobStatus (themePath: string, jobId: string, interval = 1000, retries = 10): Promise<void> {
+  CliUx.ux.action.start('Polling job status')
+
+  while (retries) {
+    // Delay issueing a retry
+    await new Promise(resolve => setTimeout(resolve, interval))
+
+    const response = await request.requestAPI(`/api/v2/guide/theming/jobs/${jobId}`)
+    const job: Job = response.data.job
+
+    switch (job.status) {
+    case 'pending':
+      retries -= 1
+      break
+    case 'completed': {
+      CliUx.ux.action.stop('Ok')
+      return
+    }
+    case 'failed': {
+      // Although `data.job.errors` is an array, it usually contains
+      // only one error at a time. Hence, we only need to handle the
+      // first error in the array.
+      const [error] = job.errors
+      handleJobError(themePath, error)
+    }
+    }
+  }
+
+  error('Import job timed out')
+}
+
+function handleJobError (themePath: string, jobError: JobError): void {
+  const { code, message, meta } = jobError
+  const title = `${chalk.bold(code)} - ${message}`
+  let details = ''
+
+  switch (code) {
+  case 'InvalidTemplates':
+  case 'InvalidManifest':
+  case 'InvalidTranslationFile':
+    details = validationErrorsToString(themePath, meta as ValidationErrors)
+    break
+  default:
+    details = JSON.stringify(meta)
+  }
+
+  error(`${title}\n${details}`)
+}
+
+export function validationErrorsToString (themePath: string, validationErrors: ValidationErrors): string {
+  let string = ''
+
+  for (const [template, errors] of Object.entries(validationErrors)) {
+    for (const { line, column, description } of errors) {
+      string += `\n${chalk.bold('Validation error')} ${themePath}/${template}${line && column ? `:${line}:${column}` : ''}\n ${description}\n`
+    }
+  }
+
+  return string
+}

--- a/packages/zcli-themes/src/lib/pollJobStatus.ts
+++ b/packages/zcli-themes/src/lib/pollJobStatus.ts
@@ -9,7 +9,7 @@ export default async function pollJobStatus (themePath: string, jobId: string, i
   CliUx.ux.action.start('Polling job status')
 
   while (retries) {
-    // Delay issueing a retry
+    // Delay issuing a retry
     await new Promise(resolve => setTimeout(resolve, interval))
 
     const response = await request.requestAPI(`/api/v2/guide/theming/jobs/${jobId}`)

--- a/packages/zcli-themes/src/lib/preview.test.ts
+++ b/packages/zcli-themes/src/lib/preview.test.ts
@@ -34,7 +34,7 @@ describe('preview', () => {
     sinon.restore()
   })
 
-  it('calls the local_preview endpoint with the correct payload and credentials', async () => {
+  it('calls the local_preview endpoint with the correct payload', async () => {
     const getManifestStub = sinon.stub(getManifest, 'default')
     const getTemplatesStub = sinon.stub(getTemplates, 'default')
     const getVariablesStub = sinon.stub(getVariables, 'default')

--- a/packages/zcli-themes/src/lib/preview.test.ts
+++ b/packages/zcli-themes/src/lib/preview.test.ts
@@ -105,12 +105,12 @@ describe('preview', () => {
         data: {
           template_errors: {
             home_page: [{
-              description: "'searcsh' does not exist",
+              description: "'articles' does not exist",
               line: 10,
               column: 6,
               length: 7
             }, {
-              description: 'not possible to access `help_centerr` in `help_centerr.name`',
+              description: 'not possible to access `user` in `user.name`',
               line: 1,
               column: 33,
               length: 10
@@ -134,9 +134,9 @@ describe('preview', () => {
       const [call] = errorStub.getCalls()
       const [error] = call.args
       expect(error).to.contain('theme/path/templates/home_page.hbs:10:6')
-      expect(error).to.contain('\'searcsh\' does not exist')
+      expect(error).to.contain('\'articles\' does not exist')
       expect(error).to.contain('theme/path/templates/home_page.hbs:1:33')
-      expect(error).to.contain('not possible to access `help_centerr` in `help_centerr.name`')
+      expect(error).to.contain('not possible to access `user` in `user.name`')
       expect(error).to.contain('theme/path/templates/footer.hbs:6:12')
       expect(error).to.contain('\'alternative_loccales\' does not exist')
     }

--- a/packages/zcli-themes/src/lib/preview.test.ts
+++ b/packages/zcli-themes/src/lib/preview.test.ts
@@ -6,7 +6,7 @@ import * as getVariables from './getVariables'
 import * as getAssets from './getAssets'
 import * as axios from 'axios'
 import { request } from '@zendesk/zcli-core'
-import * as chalk from 'chalk'
+import * as errors from '@oclif/core/lib/errors'
 import preview, { livereloadScript } from './preview'
 
 const manifest = {
@@ -66,10 +66,13 @@ describe('preview', () => {
       statusText: 'OK'
     }) as axios.AxiosPromise)
 
-    expect(await preview('theme/path', flags)).to.equal(true)
+    await preview('theme/path', flags)
 
     expect(requestStub.calledWith('/hc/api/internal/theming/local_preview', sinon.match({
       method: 'put',
+      headers: {
+        'X-Zendesk-Request-Originator': 'zcli themes:preview'
+      },
       data: {
         templates: {
           home_page: '<h1>Home</h1>',
@@ -91,60 +94,51 @@ describe('preview', () => {
     }))).to.equal(true)
   })
 
-  it('logs all the template errors when validation fails', async () => {
+  it('throws a comprehensive error when validation fails', async () => {
     sinon.stub(getManifest, 'default').returns(manifest)
     sinon.stub(getTemplates, 'default').returns({})
     sinon.stub(getVariables, 'default').returns([])
     sinon.stub(getAssets, 'default').returns([])
 
-    sinon.stub(request, 'requestAPI').returns(Promise.resolve({
-      status: 400,
-      data: {
-        template_errors: {
-          home_page: [{
-            description: "'searcsh' does not exist",
-            line: 10,
-            column: 6,
-            length: 7
-          }, {
-            description: 'not possible to access `help_centerr` in `help_centerr.name`',
-            line: 1,
-            column: 33,
-            length: 10
-          }],
-          footer: [{
-            description: "'alternative_loccales' does not exist",
-            line: 6,
-            column: 12,
-            length: 10
-          }]
+    sinon.stub(request, 'requestAPI').throws({
+      response: {
+        data: {
+          template_errors: {
+            home_page: [{
+              description: "'searcsh' does not exist",
+              line: 10,
+              column: 6,
+              length: 7
+            }, {
+              description: 'not possible to access `help_centerr` in `help_centerr.name`',
+              line: 1,
+              column: 33,
+              length: 10
+            }],
+            footer: [{
+              description: "'alternative_loccales' does not exist",
+              line: 6,
+              column: 12,
+              length: 10
+            }]
+          }
         }
       }
-    }) as axios.AxiosPromise)
+    })
 
-    const consoleLogStub = sinon.stub(console, 'log')
+    const errorStub = sinon.stub(errors, 'error').callThrough()
 
-    expect(await preview('theme/path', flags)).to.equal(false)
-
-    expect(consoleLogStub.calledWith(
-      chalk.bold.red('Validation error'),
-      'theme/path/templates/home_page.hbs:10:6',
-      '\n',
-      '\'searcsh\' does not exist'
-    )).to.equal(true)
-
-    expect(consoleLogStub.calledWith(
-      chalk.bold.red('Validation error'),
-      'theme/path/templates/home_page.hbs:1:33',
-      '\n',
-      'not possible to access `help_centerr` in `help_centerr.name`')
-    ).to.equal(true)
-
-    expect(consoleLogStub.calledWith(
-      chalk.bold.red('Validation error'),
-      'theme/path/templates/footer.hbs:6:12',
-      '\n',
-      '\'alternative_loccales\' does not exist')
-    ).to.equal(true)
+    try {
+      await preview('theme/path', flags)
+    } catch {
+      const [call] = errorStub.getCalls()
+      const [error] = call.args
+      expect(error).to.contain('theme/path/templates/home_page.hbs:10:6')
+      expect(error).to.contain('\'searcsh\' does not exist')
+      expect(error).to.contain('theme/path/templates/home_page.hbs:1:33')
+      expect(error).to.contain('not possible to access `help_centerr` in `help_centerr.name`')
+      expect(error).to.contain('theme/path/templates/footer.hbs:6:12')
+      expect(error).to.contain('\'alternative_loccales\' does not exist')
+    }
   })
 })

--- a/packages/zcli-themes/src/lib/preview.ts
+++ b/packages/zcli-themes/src/lib/preview.ts
@@ -1,21 +1,15 @@
-import type { Flags, ValidationErrors } from '../types'
+import type { Flags, ValidationError, ValidationErrors } from '../types'
 import getManifest from './getManifest'
 import getTemplates from './getTemplates'
 import getVariables from './getVariables'
 import getAssets from './getAssets'
 import * as chalk from 'chalk'
 import { request } from '@zendesk/zcli-core'
-import { CLIError } from '@oclif/core/lib/errors'
+import { error } from '@oclif/core/lib/errors'
 import { CliUx } from '@oclif/core'
+import validationErrorsToString from './validationErrorsToString'
 
-export const livereloadScript = (host: string, port: number) => `<script>(() => {
-  const socket = new WebSocket('ws://${host}:${port}/livereload');
-  socket.onopen = () => console.log('Listening to theme changes...');
-  socket.onmessage = e => e.data === 'reload' && location.reload();
-})()</script>
-`
-
-export default async function preview (themePath: string, flags: Flags): Promise<boolean | void> | never {
+export default async function preview (themePath: string, flags: Flags): Promise<void> {
   const manifest = getManifest(themePath)
   const templates = getTemplates(themePath)
   const variables = getVariables(themePath, manifest.settings, flags)
@@ -36,9 +30,8 @@ export default async function preview (themePath: string, flags: Flags): Promise
 
   try {
     CliUx.ux.action.start('Uploading theme')
-    const response = await request.requestAPI('/hc/api/internal/theming/local_preview', {
+    await request.requestAPI('/hc/api/internal/theming/local_preview', {
       method: 'put',
-      validateStatus: null,
       headers: {
         'X-Zendesk-Request-Originator': 'zcli themes:preview'
       },
@@ -57,31 +50,42 @@ export default async function preview (themePath: string, flags: Flags): Promise
           variables: variablesPayload,
           metadata: metadataPayload
         }
-      }
+      },
+      validateStatus: (status: number) => status === 200
     })
-
-    if (response.status === 200) {
-      CliUx.ux.action.stop('Ok')
-      return true
+    CliUx.ux.action.stop('Ok')
+  } catch (e) {
+    CliUx.ux.action.stop(chalk.bold.red('!'))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { template_errors } = (e as any).response.data
+    if (template_errors) {
+      handlePreviewError(themePath, template_errors)
     } else {
-      CliUx.ux.action.stop('Failed')
-      const data = response.data
-      if (!data.template_errors) throw new CLIError(response.statusText)
-      Object.entries(data.template_errors as ValidationErrors).forEach(([template, errors]) => {
-        errors.forEach(({ line, column, description }) => {
-          console.log(
-            chalk.bold.red('Validation error'),
-            `${themePath}/templates/${template}.hbs:${line}:${column}`,
-            '\n',
-            description
-          )
-        })
-      })
-      return false
+      error('Something went wrong')
     }
-  } catch (error) {
-    CliUx.ux.action.stop('Failed')
-    console.log(chalk.bold.red('Error'), 'Something went wrong')
-    throw (error)
   }
+}
+
+export function livereloadScript (host: string, port: number) {
+  return `<script>(() => {
+    const socket = new WebSocket('ws://${host}:${port}/livereload');
+    socket.onopen = () => console.log('Listening to theme changes...');
+    socket.onmessage = e => e.data === 'reload' && location.reload();
+  })()</script>
+  `
+}
+
+function handlePreviewError (themePath: string, templateErrors: ValidationErrors) {
+  const validationErrors: ValidationErrors = {}
+  for (const [template, errors] of Object.entries(templateErrors)) {
+    // the preview endpoint returns the template identifier as the 'key' instead of
+    // the template path. We must fix this so we can reuse `validationErrorsToString`
+    // and align with the job import error handling
+    validationErrors[`templates/${template}.hbs`] = errors as ValidationError[]
+  }
+
+  const title = `${chalk.bold('InvalidTemplates')} - Template(s) with syntax error(s)`
+  const details = validationErrorsToString(themePath, validationErrors)
+
+  error(`${title}\n${details}`)
 }

--- a/packages/zcli-themes/src/lib/preview.ts
+++ b/packages/zcli-themes/src/lib/preview.ts
@@ -1,4 +1,4 @@
-import type { Flags, TemplateErrors } from '../types'
+import type { Flags, ValidationErrors } from '../types'
 import getManifest from './getManifest'
 import getTemplates from './getTemplates'
 import getVariables from './getVariables'
@@ -67,7 +67,7 @@ export default async function preview (themePath: string, flags: Flags): Promise
       CliUx.ux.action.stop('Failed')
       const data = response.data
       if (!data.template_errors) throw new CLIError(response.statusText)
-      Object.entries(data.template_errors as TemplateErrors).forEach(([template, errors]) => {
+      Object.entries(data.template_errors as ValidationErrors).forEach(([template, errors]) => {
         errors.forEach(({ line, column, description }) => {
           console.log(
             chalk.bold.red('Validation error'),

--- a/packages/zcli-themes/src/lib/uploadThemePackage.test.ts
+++ b/packages/zcli-themes/src/lib/uploadThemePackage.test.ts
@@ -1,0 +1,58 @@
+import * as sinon from 'sinon'
+import { expect } from '@oclif/test'
+import * as axios from 'axios'
+import { request } from '@zendesk/zcli-core'
+import uploadThemePackage, { themeSizeLimit } from './uploadThemePackage'
+import * as errors from '@oclif/core/lib/errors'
+import * as fs from 'fs'
+import * as FormData from 'form-data'
+
+const job = {
+  id: '9999',
+  status: 'pending' as const,
+  data: {
+    theme_id: '1234',
+    upload: {
+      url: 'upload/url',
+      parameters: {
+        foo: 'foo',
+        bar: 'bar'
+      }
+    }
+  }
+}
+
+describe('uploadThemePackage', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('calls the job upload endpoint with the correct payload and returns the job', async () => {
+    const readStreamStub = sinon.createStubInstance(fs.ReadStream)
+    const requestStub = sinon.stub(request, 'requestAPI')
+
+    await uploadThemePackage(job, readStreamStub)
+
+    expect(requestStub.calledWith('upload/url', sinon.match({
+      method: 'POST',
+      data: sinon.match.instanceOf(FormData),
+      maxBodyLength: themeSizeLimit,
+      maxContentLength: themeSizeLimit
+    }))).to.equal(true)
+  })
+
+  it('errors when the upload fails', async () => {
+    const readStreamStub = sinon.createStubInstance(fs.ReadStream)
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const errorStub = sinon.stub(errors, 'error').callThrough()
+    const error = new axios.AxiosError('Network error')
+
+    requestStub.throws(error)
+
+    try {
+      await uploadThemePackage(job, readStreamStub)
+    } catch {
+      expect(errorStub.calledWith(error)).to.equal(true)
+    }
+  })
+})

--- a/packages/zcli-themes/src/lib/uploadThemePackage.ts
+++ b/packages/zcli-themes/src/lib/uploadThemePackage.ts
@@ -1,0 +1,33 @@
+import type { PendingJob } from '../types'
+import { CliUx } from '@oclif/core'
+import * as fs from 'fs'
+import * as FormData from 'form-data'
+import * as axios from 'axios'
+import { request } from '@zendesk/zcli-core'
+import { error } from '@oclif/core/lib/errors'
+
+export const themeSizeLimit = 31457280
+
+export default async function uploadThemePackage (job: PendingJob, readStream: fs.ReadStream): Promise<void> {
+  CliUx.ux.action.start('Uploading theme package')
+
+  const formData = new FormData()
+
+  for (const key in job.data.upload.parameters) {
+    formData.append(key, job.data.upload.parameters[key])
+  }
+
+  formData.append('file', readStream)
+
+  try {
+    await request.requestAPI(job.data.upload.url, {
+      method: 'POST',
+      data: formData,
+      maxBodyLength: themeSizeLimit,
+      maxContentLength: themeSizeLimit
+    })
+    CliUx.ux.action.stop('Ok')
+  } catch (e) {
+    error(e as axios.AxiosError)
+  }
+}

--- a/packages/zcli-themes/src/lib/validationErrorsToString.test.ts
+++ b/packages/zcli-themes/src/lib/validationErrorsToString.test.ts
@@ -1,0 +1,42 @@
+import { expect } from '@oclif/test'
+import validationErrorsToString from './validationErrorsToString'
+
+describe('validationErrorsToString', () => {
+  it('returns a formatted string containing all validation errors', () => {
+    const validationErrors = {
+      'templates/home_page.hbs': [
+        {
+          description: 'not possible to access `names` in `help_center.names`',
+          line: 1,
+          column: 45,
+          length: 5
+        },
+        {
+          description: "'categoriess' does not exist",
+          line: 21,
+          column: 16,
+          length: 11
+        }
+      ],
+      'templates/new_request_page.hbs': [
+        {
+          description: "'request_fosrm' does not exist",
+          line: 22,
+          column: 6,
+          length: 10
+        }
+      ]
+    }
+
+    const string = validationErrorsToString('theme/path', validationErrors)
+
+    expect(string).to.contain('theme/path/templates/home_page.hbs:1:45')
+    expect(string).to.contain('not possible to access `names` in `help_center.names`')
+
+    expect(string).to.contain('theme/path/templates/home_page.hbs:21:16')
+    expect(string).to.contain("'categoriess' does not exist")
+
+    expect(string).to.contain('templates/new_request_page.hbs')
+    expect(string).to.contain("'request_fosrm' does not exist")
+  })
+})

--- a/packages/zcli-themes/src/lib/validationErrorsToString.test.ts
+++ b/packages/zcli-themes/src/lib/validationErrorsToString.test.ts
@@ -12,7 +12,7 @@ describe('validationErrorsToString', () => {
           length: 5
         },
         {
-          description: "'categoriess' does not exist",
+          description: "'articles' does not exist",
           line: 21,
           column: 16,
           length: 11
@@ -20,7 +20,7 @@ describe('validationErrorsToString', () => {
       ],
       'templates/new_request_page.hbs': [
         {
-          description: "'request_fosrm' does not exist",
+          description: "'post_form' does not exist",
           line: 22,
           column: 6,
           length: 10
@@ -34,9 +34,9 @@ describe('validationErrorsToString', () => {
     expect(string).to.contain('not possible to access `names` in `help_center.names`')
 
     expect(string).to.contain('theme/path/templates/home_page.hbs:21:16')
-    expect(string).to.contain("'categoriess' does not exist")
+    expect(string).to.contain("'articles' does not exist")
 
     expect(string).to.contain('templates/new_request_page.hbs')
-    expect(string).to.contain("'request_fosrm' does not exist")
+    expect(string).to.contain("'post_form' does not exist")
   })
 })

--- a/packages/zcli-themes/src/lib/validationErrorsToString.ts
+++ b/packages/zcli-themes/src/lib/validationErrorsToString.ts
@@ -1,0 +1,14 @@
+import type { ValidationErrors } from '../types'
+import * as chalk from 'chalk'
+
+export default function validationErrorsToString (themePath: string, validationErrors: ValidationErrors): string {
+  let string = ''
+
+  for (const [template, errors] of Object.entries(validationErrors)) {
+    for (const { line, column, description } of errors) {
+      string += `\n${chalk.bold('Validation error')} ${themePath}/${template}${line && column ? `:${line}:${column}` : ''}\n ${description}\n`
+    }
+  }
+
+  return string
+}

--- a/packages/zcli-themes/src/types.ts
+++ b/packages/zcli-themes/src/types.ts
@@ -21,13 +21,55 @@ export type Manifest = {
   settings: Setting[]
 }
 
-type TemplateError = {
+export type ValidationError = {
   description: string,
-  line: number,
-  column: number,
-  length: number
+  line?: number,
+  column?: number,
+  length?: number
 }
 
-export type TemplateErrors = {
-  [key: string]: TemplateError[]
+export type ValidationErrors = {
+  [path: string]: ValidationError[]
 }
+
+export type Brand = {
+  id: number,
+  name: string,
+}
+
+export type JobError = {
+  title: string,
+  code: string,
+  message: string,
+  meta: object
+}
+
+type JobData = {
+  theme_id: string,
+  upload: {
+    url: string,
+    parameters: {
+      [key: string]: string
+    }
+  }
+}
+
+export type PendingJob = {
+  id: string,
+  status: 'pending',
+  data: JobData
+}
+
+export type CompletedJob = {
+  id: string,
+  status: 'completed',
+  data: JobData
+}
+
+export type FailedJob = {
+  id: string,
+  status: 'failed',
+  errors: JobError[]
+}
+
+export type Job = PendingJob | CompletedJob | FailedJob

--- a/packages/zcli-themes/src/types.ts
+++ b/packages/zcli-themes/src/types.ts
@@ -29,7 +29,7 @@ export type ValidationError = {
 }
 
 export type ValidationErrors = {
-  [path: string]: ValidationError[]
+  [path: `templates/${string}.hbs`]: ValidationError[]
 }
 
 export type Brand = {

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -1,0 +1,134 @@
+import type { Job } from '../../../zcli-themes/src/types'
+import { expect, test } from '@oclif/test'
+import * as path from 'path'
+import * as nock from 'nock'
+import ImportCommand from '../../src/commands/themes/import'
+
+describe('themes:import', function () {
+  const baseThemePath = path.join(__dirname, 'mocks/base_theme')
+  const job: Job = {
+    id: '9999',
+    status: 'pending',
+    data: {
+      theme_id: '1234',
+      upload: {
+        url: 'https://s3.com/upload/path',
+        parameters: {}
+      }
+    }
+  }
+
+  describe('successful import', () => {
+    test
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => {
+        api
+          .post('/api/v2/guide/theming/jobs/themes/imports')
+          .reply(202, { job })
+
+        api
+          .get('/api/v2/guide/theming/jobs/9999')
+          .reply(200, { job: { ...job, status: 'completed' } })
+      })
+      .nock('https://s3.com', (api) => {
+        api
+          .post('/upload/path')
+          .reply(200)
+      })
+      .stdout()
+      .it('should display success message when the theme is imported successfully', async ctx => {
+        await ImportCommand.run([baseThemePath, '--brandId', '1111'])
+        expect(ctx.stdout).to.contain('Theme imported successfully theme ID: 1234')
+      })
+  })
+
+  describe('import failure', () => {
+    test
+      .stderr()
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => {
+        api
+          .post('/api/v2/guide/theming/jobs/themes/imports')
+          .reply(400, {
+            errors: [{
+              code: 'TooManyThemes',
+              title: 'Maximum number of allowed themes reached'
+            }]
+          })
+      })
+      .it('should report errors when creating the import job fails', async (ctx) => {
+        try {
+          await ImportCommand.run([baseThemePath, '--brandId', '1111'])
+        } catch (error) {
+          expect(ctx.stderr).to.contain('Creating theme import job... !')
+          expect(error.message).to.contain('TooManyThemes')
+          expect(error.message).to.contain('Maximum number of allowed themes reached')
+        } finally {
+          nock.cleanAll()
+        }
+      })
+
+    test
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => {
+        api
+          .post('/api/v2/guide/theming/jobs/themes/imports')
+          .reply(202, { job })
+
+        api
+          .get('/api/v2/guide/theming/jobs/9999')
+          .reply(200, {
+            job: {
+              ...job,
+              status: 'failed',
+              data: null,
+              errors: [
+                {
+                  message: 'Template(s) with syntax error(s)',
+                  code: 'InvalidTemplates',
+                  meta: {
+                    'templates/new_request_page.hbs': [
+                      {
+                        description: "'request_fosrm' does not exist",
+                        line: 22,
+                        column: 6,
+                        length: 10
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          })
+      })
+      .nock('https://s3.com', (api) => {
+        api
+          .post('/upload/path')
+          .reply(200)
+      })
+      .it('should report validation errors', async (ctx) => {
+        try {
+          await ImportCommand.run([baseThemePath, '--brandId', '1111'])
+        } catch (error) {
+          expect(error.message).to.contain('InvalidTemplates')
+          expect(error.message).to.contain('Template(s) with syntax error(s)')
+          expect(error.message).to.contain('Validation error')
+          expect(error.message).to.contain("'request_fosrm' does not exist")
+        } finally {
+          nock.cleanAll()
+        }
+      })
+  })
+})

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -118,7 +118,7 @@ describe('themes:import', function () {
           .post('/upload/path')
           .reply(200)
       })
-      .it('should report validation errors', async (ctx) => {
+      .it('should report validation errors', async () => {
         try {
           await ImportCommand.run([baseThemePath, '--brandId', '1111'])
         } catch (error) {

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -68,7 +68,7 @@ describe('themes:import', function () {
         try {
           await ImportCommand.run([baseThemePath, '--brandId', '1111'])
         } catch (error) {
-          expect(ctx.stderr).to.contain('Creating theme import job... !')
+          expect(ctx.stderr).to.contain('!')
           expect(error.message).to.contain('TooManyThemes')
           expect(error.message).to.contain('Maximum number of allowed themes reached')
         } finally {

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -101,7 +101,7 @@ describe('themes:import', function () {
                   meta: {
                     'templates/new_request_page.hbs': [
                       {
-                        description: "'request_fosrm' does not exist",
+                        description: "'post_form' does not exist",
                         line: 22,
                         column: 6,
                         length: 10
@@ -125,7 +125,7 @@ describe('themes:import', function () {
           expect(error.message).to.contain('InvalidTemplates')
           expect(error.message).to.contain('Template(s) with syntax error(s)')
           expect(error.message).to.contain('Validation error')
-          expect(error.message).to.contain("'request_fosrm' does not exist")
+          expect(error.message).to.contain("'post_form' does not exist")
         } finally {
           nock.cleanAll()
         }

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -87,9 +87,9 @@ describe('themes:preview', function () {
 
         try {
           await PreviewCommand.run([baseThemePath])
-        } catch {
           expect(ctx.stdout).to.contain(`Validation error ${baseThemePath}/templates/home_page.hbs:10:6`)
           expect(ctx.stdout).to.contain("'searcsh' does not exist")
+        } catch {
         } finally {
           nock.cleanAll()
         }

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -66,6 +66,10 @@ describe('themes:preview', function () {
   })
 
   describe('validation errors', () => {
+    after(() => {
+      nock.cleanAll()
+    })
+
     test
       .stdout()
       .env({
@@ -89,10 +93,7 @@ describe('themes:preview', function () {
           await PreviewCommand.run([baseThemePath])
           expect(ctx.stdout).to.contain(`Validation error ${baseThemePath}/templates/home_page.hbs:10:6`)
           expect(ctx.stdout).to.contain("'searcsh' does not exist")
-        } catch {
-        } finally {
-          nock.cleanAll()
-        }
+        } catch {}
       })
   })
 })

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -81,7 +81,7 @@ describe('themes:preview', function () {
         nock('https://z3ntest.zendesk.com').put('/hc/api/internal/theming/local_preview').reply(400, {
           template_errors: {
             home_page: [{
-              description: "'searcsh' does not exist",
+              description: "'articles' does not exist",
               line: 10,
               column: 6,
               length: 7
@@ -92,7 +92,7 @@ describe('themes:preview', function () {
         try {
           await PreviewCommand.run([baseThemePath])
           expect(ctx.stdout).to.contain(`Validation error ${baseThemePath}/templates/home_page.hbs:10:6`)
-          expect(ctx.stdout).to.contain("'searcsh' does not exist")
+          expect(ctx.stdout).to.contain("'articles' does not exist")
         } catch {}
       })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,14 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/inquirer@^8.0.0":
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-8.2.6.tgz#abd41a5fb689c7f1acb12933d787d4262a02a0ab"
+  integrity sha512-3uT88kxg8lNzY8ay2ZjP44DKcRaTGztqeIvN2zHvhzIBH/uAPaL75aBtdNRKbA7xXoMbBt5kX0M00VKAnfOYlA==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^7.2.0"
+
 "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -1704,6 +1712,13 @@
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz#bf2e02a3dbd4aecaf95942ecd99b7402e03fad5e"
   integrity sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/uuid@^8.3.4":
   version "8.3.4"
@@ -4524,7 +4539,7 @@ inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inquirer@^8.2.5:
+inquirer@^8.0.0, inquirer@^8.2.5:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
   integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
@@ -6961,6 +6976,13 @@ rxjs@^6.6.0:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.2.0:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
 
 rxjs@^7.5.5:
   version "7.5.6"


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`b6c615c`](https://github.com/zendesk/zcli/pull/179/commits/b6c615c9cc44571cf463b4d8e42f96982a261901) Bring in inquirer package



### [`5889bce`](https://github.com/zendesk/zcli/pull/179/commits/5889bce25beed82b9e92618bb6f6c8711c50da90) Add theme Job types



### [`ad45a71`](https://github.com/zendesk/zcli/pull/179/commits/ad45a719ec6f1ccb8ef1067f8f7d88b284be8ae2) Add a module to get the brand Id



### [`be40646`](https://github.com/zendesk/zcli/pull/179/commits/be40646d41ce907164353ed2cbc1cd5d4e6d962a) Add a module to create a theme Import job



### [`334c697`](https://github.com/zendesk/zcli/pull/179/commits/334c697936519996c2b28a653af4ba9c14fda33a) Add a module to create a theme package



### [`e83ea32`](https://github.com/zendesk/zcli/pull/179/commits/e83ea324752dc5e701cea7331646cd2ec1531650) Add a module to upload a theme package



### [`32afe39`](https://github.com/zendesk/zcli/pull/179/commits/32afe39e35a16441652582aa28fe9f2f2d521920) Add a module to poll the job status



### [`c9b8fe8`](https://github.com/zendesk/zcli/pull/179/commits/c9b8fe837b54d0ae754393fe477d5358cf574e6d) feat: add a themes:import command



### [`d3d2671`](https://github.com/zendesk/zcli/pull/179/commits/d3d2671d9d8d7817d8857213848a713f578b1841) Cover themes:import with functional tests



### [`be55932`](https://github.com/zendesk/zcli/pull/179/commits/be55932e382a656c6b2bd74a7dfd646a5059a11f) Document themes:import



### [`73d9e47`](https://github.com/zendesk/zcli/pull/179/commits/73d9e47e505b2870b0c7aa2a97acc811f5862cdb) Fix failure on ubunto build



### [`7b105ab`](https://github.com/zendesk/zcli/pull/179/commits/7b105ab1623248f46f3e7a73aa62dc2629e3b995) Annotate theme import call with request originator



### [`4d5a2d1`](https://github.com/zendesk/zcli/pull/179/commits/4d5a2d1e7017f61b7acaa7f3be0ac1771519b0fe) Align preview error handling with import



### [`3b2e0cd`](https://github.com/zendesk/zcli/pull/179/commits/3b2e0cd8f24a9d05ee06454a5794163ddc7d2339) Address PR feedback



### [`21c073b`](https://github.com/zendesk/zcli/pull/179/commits/21c073b4bfdbcb2b850838d538881bb85066e2d1) Address PR feedback



### [`d4bb029`](https://github.com/zendesk/zcli/pull/179/commits/d4bb0294b952e990ec948e9f61c062085e259bf7) Remove ambiguity around valiation error namings in specs



### [`3e0e9f5`](https://github.com/zendesk/zcli/pull/179/commits/3e0e9f58216aebf6fe3024a887afc1d4ce3a2afc) Address linting error



### [`d2074ca`](https://github.com/zendesk/zcli/pull/179/commits/d2074ca42d837feb88edfd60d3be5302c55c490b) Merge branch 'master' into luis.theme_import



<!-- === GH HISTORY FENCE === -->

## Detail

This PR adds support for `zcli theme:import` and automates the steps necessary to import a theme into a target account/brand without having to leave the local development environment.

## Checklist

- [x] :guardsman: includes new unit and functional tests
