### PR TITLE
Support for zcli themes:publish

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -6,10 +6,11 @@ zcli themes commands helps with managing Zendesk Help Center theming workflow.
 * [`zcli themes:preview [THEMEDIRECTORY]`](#zcli-themespreview-themedirectory)
 * [`zcli themes:import [THEMEDIRECTORY]`](#zcli-themesimport-themedirectory)
 * [`zcli themes:update [THEMEDIRECTORY]`](#zcli-themesupdate-themedirectory)
+* [`zcli themes:publish`](#zcli-themespublish)
 
 ## Configuration
 
-NOTE: preview requires login so make sure to first run `zcli login -i`
+NOTE: theme commands require login so make sure to first run `zcli login -i`
 
 ## `zcli themes:preview [THEMEDIRECTORY]`
 
@@ -33,12 +34,6 @@ EXAMPLES
   $ zcli themes:preview ./copenhagen_theme --port=9999
   $ zcli themes:preview ./copenhagen_theme --no-livereload
 ```
-
-* [`zcli themes:import [THEMEDIRECTORY]`](#zcli-themesimport-themedirectory)
-
-## Configuration
-
-NOTE: import requires login so make sure to first run `zcli login -i`
 
 ## `zcli themes:import [THEMEDIRECTORY]`
 
@@ -77,4 +72,19 @@ OPTIONS
 EXAMPLES
   $ zcli themes:update ./copenhagen_theme --themeId=123456789100
   $ zcli themes:update ./copenhagen_theme --themeId=123456789100 --replaceSettings
+```
+
+## `zcli themes:publish`
+
+publishes a theme
+
+```
+USAGE
+  $ zcli themes:publish
+
+OPTIONS
+  --themeId       The id of the theme to publish
+
+EXAMPLES
+  $ zcli themes:import --themeId=123456789100
 ```

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -86,5 +86,5 @@ OPTIONS
   --themeId       The id of the theme to publish
 
 EXAMPLES
-  $ zcli themes:import --themeId=123456789100
+  $ zcli themes:publish --themeId=123456789100
 ```

--- a/packages/zcli-themes/src/commands/themes/publish.ts
+++ b/packages/zcli-themes/src/commands/themes/publish.ts
@@ -1,0 +1,43 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import { request } from '@zendesk/zcli-core'
+import * as chalk from 'chalk'
+
+export default class Publish extends Command {
+  static description = 'publish a theme'
+
+  static flags = {
+    themeId: Flags.string({ description: 'The id of the theme to publish' })
+  }
+
+  static args = [
+    { name: 'themeDirectory', required: true, default: '.' }
+  ]
+
+  static examples = [
+    '$ zcli themes:publish --themeId=abcd'
+  ]
+
+  static strict = false
+
+  async run () {
+    let { flags: { themeId } } = await this.parse(Publish)
+
+    themeId = themeId || await CliUx.ux.prompt('Theme ID')
+
+    try {
+      CliUx.ux.action.start('Publishing theme')
+      await request.requestAPI(`/api/v2/guide/theming/themes/${themeId}/publish`, {
+        method: 'post',
+        headers: {
+          'X-Zendesk-Request-Originator': 'zcli themes:publish'
+        },
+        validateStatus: (status: number) => status === 200
+      })
+      CliUx.ux.action.stop('Ok')
+      this.log(chalk.green('Theme published successfully'), `theme ID: ${themeId}`)
+    } catch (e: any) {
+      const [error] = e.response.data.errors
+      this.error(`${error.code} - ${error.title}`)
+    }
+  }
+}

--- a/packages/zcli-themes/src/commands/themes/publish.ts
+++ b/packages/zcli-themes/src/commands/themes/publish.ts
@@ -9,10 +9,6 @@ export default class Publish extends Command {
     themeId: Flags.string({ description: 'The id of the theme to publish' })
   }
 
-  static args = [
-    { name: 'themeDirectory', required: true, default: '.' }
-  ]
-
   static examples = [
     '$ zcli themes:publish --themeId=abcd'
   ]

--- a/packages/zcli-themes/tests/functional/publish.test.ts
+++ b/packages/zcli-themes/tests/functional/publish.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@oclif/test'
+import PublishCommand from '../../src/commands/themes/publish'
+
+describe('themes:publish', function () {
+  describe('successful publish', () => {
+    test
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => api
+        .post('/api/v2/guide/theming/themes/1234/publish')
+        .reply(200))
+      .stdout()
+      .it('should display success message when the theme is published successfully', async ctx => {
+        await PublishCommand.run(['--themeId', '1234'])
+        expect(ctx.stdout).to.contain('Theme published successfully theme ID: 1234')
+      })
+  })
+
+  describe('publish failure', () => {
+    test
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => api
+        .post('/api/v2/guide/theming/themes/1234/publish')
+        .reply(400, {
+          errors: [{
+            code: 'ThemeNotFound',
+            title: 'Invalid id'
+          }]
+        }))
+      .stderr()
+      .it('should report publish errors', async ctx => {
+        try {
+          await PublishCommand.run(['--themeId', '1234'])
+        } catch (error) {
+          expect(ctx.stderr).to.contain('!')
+          expect(error.message).to.contain('ThemeNotFound - Invalid id')
+        }
+      })
+  })
+})


### PR DESCRIPTION
Adding a new `zcli themes:publish` command to set a theme as live.

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`5842284`](https://github.com/zendesk/zcli/pull/181/commits/5842284a131e096ae38c9f605b72c68fe3204b62) feat: add a themes:publish command



### [`4f509fe`](https://github.com/zendesk/zcli/pull/181/commits/4f509fea8d018538b82852080e9efe82b1adec9b) Applying PR feedback



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
