### PR TITLE
Support for zcli themes:update

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -75,6 +75,6 @@ OPTIONS
   --replaceSettings       Whether or not to replace the current theme settings
 
 EXAMPLES
-  $ zcli themes:import ./copenhagen_theme --themeId=123456789100
-  $ zcli themes:import ./copenhagen_theme --themeId=123456789100 --replaceSettings
+  $ zcli themes:update ./copenhagen_theme --themeId=123456789100
+  $ zcli themes:update ./copenhagen_theme --themeId=123456789100 --replaceSettings
 ```

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -72,7 +72,7 @@ ARGUMENTS
 
 OPTIONS
   --themeId               The id of the theme to update
-  --replaceSettings       Whether or not to replace the current theme settings
+  --replaceSettings       [default: false] Whether or not to replace the current theme settings
 
 EXAMPLES
   $ zcli themes:update ./copenhagen_theme --themeId=123456789100

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -4,6 +4,8 @@
 zcli themes commands helps with managing Zendesk Help Center theming workflow.
 
 * [`zcli themes:preview [THEMEDIRECTORY]`](#zcli-themespreview-themedirectory)
+* [`zcli themes:import [THEMEDIRECTORY]`](#zcli-themesimport-themedirectory)
+* [`zcli themes:update [THEMEDIRECTORY]`](#zcli-themesupdate-themedirectory)
 
 ## Configuration
 
@@ -55,4 +57,24 @@ OPTIONS
 EXAMPLES
   $ zcli themes:import ./copenhagen_theme
   $ zcli themes:import ./copenhagen_theme --brandId=123456789100
+```
+
+## `zcli themes:update [THEMEDIRECTORY]`
+
+updates a theme
+
+```
+USAGE
+  $ zcli themes:update [THEMEDIRECTORY]
+
+ARGUMENTS
+  THEMEDIRECTORY  [default: .] theme path where manifest.json exists
+
+OPTIONS
+  --themeId               The id of the theme to update
+  --replaceSettings       Whether or not to replace the current theme settings
+
+EXAMPLES
+  $ zcli themes:import ./copenhagen_theme --themeId=123456789100
+  $ zcli themes:import ./copenhagen_theme --themeId=123456789100 --replaceSettings
 ```

--- a/packages/zcli-themes/src/commands/themes/update.ts
+++ b/packages/zcli-themes/src/commands/themes/update.ts
@@ -1,0 +1,46 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import * as path from 'path'
+import * as chalk from 'chalk'
+import createThemeUpdateJob from '../../lib/createThemeUpdateJob'
+import createThemePackage from '../../lib/createThemePackage'
+import uploadThemePackage from '../../lib/uploadThemePackage'
+import pollJobStatus from '../../lib/pollJobStatus'
+
+export default class Update extends Command {
+  static description = 'import a theme'
+
+  static flags = {
+    themeId: Flags.string({ description: 'The id of the theme to update' }),
+    replaceSettings: Flags.boolean({ default: false, description: 'Whether or not to replace the current theme settings' })
+  }
+
+  static args = [
+    { name: 'themeDirectory', required: true, default: '.' }
+  ]
+
+  static examples = [
+    '$ zcli themes:import ./copenhagen_theme'
+  ]
+
+  static strict = false
+
+  async run () {
+    let { flags: { themeId, replaceSettings }, argv: [themeDirectory] } = await this.parse(Update)
+    const themePath = path.resolve(themeDirectory)
+
+    themeId = themeId || await CliUx.ux.prompt('Theme ID')
+
+    const job = await createThemeUpdateJob(themeId, replaceSettings)
+    const { readStream, removePackage } = await createThemePackage(themePath)
+
+    try {
+      await uploadThemePackage(job, readStream)
+    } finally {
+      removePackage()
+    }
+
+    await pollJobStatus(themePath, job.id)
+
+    this.log(chalk.green('Theme updated successfully'))
+  }
+}

--- a/packages/zcli-themes/src/commands/themes/update.ts
+++ b/packages/zcli-themes/src/commands/themes/update.ts
@@ -19,7 +19,7 @@ export default class Update extends Command {
   ]
 
   static examples = [
-    '$ zcli themes:import ./copenhagen_theme'
+    '$ zcli themes:update ./copenhagen_theme' --themeId=123456789100
   ]
 
   static strict = false

--- a/packages/zcli-themes/src/commands/themes/update.ts
+++ b/packages/zcli-themes/src/commands/themes/update.ts
@@ -19,7 +19,8 @@ export default class Update extends Command {
   ]
 
   static examples = [
-    '$ zcli themes:update ./copenhagen_theme' --themeId=123456789100
+    '$ zcli themes:update ./copenhagen_theme --themeId=123456789100',
+    '$ zcli themes:update ./copenhagen_theme --themeId=123456789100 --replaceSettings'
   ]
 
   static strict = false

--- a/packages/zcli-themes/src/lib/createThemeUpdateJob.test.ts
+++ b/packages/zcli-themes/src/lib/createThemeUpdateJob.test.ts
@@ -1,0 +1,60 @@
+import * as sinon from 'sinon'
+import { expect } from '@oclif/test'
+import * as axios from 'axios'
+import { request } from '@zendesk/zcli-core'
+import createThemeUpdateJob from './createThemeUpdateJob'
+import * as chalk from 'chalk'
+import * as errors from '@oclif/core/lib/errors'
+
+describe('createThemeUpdateJob', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('calls the jobs/themes/updates endpoint with the correct payload and returns the job', async () => {
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const job = {
+      id: '9999',
+      status: 'pending',
+      data: {}
+    }
+
+    requestStub.returns(Promise.resolve({ data: { job } }) as axios.AxiosPromise)
+
+    expect(await createThemeUpdateJob('1234', true)).to.equal(job)
+
+    expect(requestStub.calledWith('/api/v2/guide/theming/jobs/themes/updates', sinon.match({
+      method: 'POST',
+      data: {
+        job: {
+          attributes: {
+            theme_id: '1234',
+            replace_settings: true,
+            format: 'zip'
+          }
+        }
+      }
+    }))).to.equal(true)
+  })
+
+  it('errors when creation fails', async () => {
+    const errorStub = sinon.stub(errors, 'error').callThrough()
+
+    sinon.stub(request, 'requestAPI').throws({
+      response: {
+        data: {
+          errors: [{
+            code: 'TooManyThemes',
+            title: 'Maximum number of allowed themes reached'
+          }]
+        }
+      }
+    })
+
+    try {
+      await createThemeUpdateJob('1234', false)
+    } catch {
+      expect(errorStub.calledWith(`${chalk.bold('TooManyThemes')} - Maximum number of allowed themes reached`)).to.equal(true)
+    }
+  })
+})

--- a/packages/zcli-themes/src/lib/createThemeUpdateJob.ts
+++ b/packages/zcli-themes/src/lib/createThemeUpdateJob.ts
@@ -4,19 +4,20 @@ import { request } from '@zendesk/zcli-core'
 import * as chalk from 'chalk'
 import { error } from '@oclif/core/lib/errors'
 
-export default async function createThemeImportJob (brandId: string): Promise<PendingJob> {
-  CliUx.ux.action.start('Creating theme import job')
+export default async function createThemeUpdateJob (themeId: string, replaceSettings: boolean): Promise<PendingJob> {
+  CliUx.ux.action.start('Creating theme update job')
 
   try {
-    const { data: { job } } = await request.requestAPI('/api/v2/guide/theming/jobs/themes/imports', {
+    const { data: { job } } = await request.requestAPI('/api/v2/guide/theming/jobs/themes/updates', {
       method: 'POST',
       headers: {
-        'X-Zendesk-Request-Originator': 'zcli themes:import'
+        'X-Zendesk-Request-Originator': 'zcli themes:update'
       },
       data: {
         job: {
           attributes: {
-            brand_id: brandId,
+            theme_id: themeId,
+            replace_settings: replaceSettings,
             format: 'zip'
           }
         }

--- a/packages/zcli-themes/tests/functional/update.test.ts
+++ b/packages/zcli-themes/tests/functional/update.test.ts
@@ -1,0 +1,134 @@
+import type { Job } from '../../../zcli-themes/src/types'
+import { expect, test } from '@oclif/test'
+import * as path from 'path'
+import * as nock from 'nock'
+import UpdateCommand from '../../src/commands/themes/update'
+
+describe('themes:update', function () {
+  const baseThemePath = path.join(__dirname, 'mocks/base_theme')
+  const job: Job = {
+    id: '9999',
+    status: 'pending',
+    data: {
+      theme_id: '1234',
+      upload: {
+        url: 'https://s3.com/upload/path',
+        parameters: {}
+      }
+    }
+  }
+
+  describe('successful update', () => {
+    test
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => {
+        api
+          .post('/api/v2/guide/theming/jobs/themes/updates')
+          .reply(202, { job })
+
+        api
+          .get('/api/v2/guide/theming/jobs/9999')
+          .reply(200, { job: { ...job, status: 'completed' } })
+      })
+      .nock('https://s3.com', (api) => {
+        api
+          .post('/upload/path')
+          .reply(200)
+      })
+      .stdout()
+      .it('should display success message when the theme is updated successfully', async ctx => {
+        await UpdateCommand.run([baseThemePath, '--themeId', '1234'])
+        expect(ctx.stdout).to.contain('Theme updated successfully')
+      })
+  })
+
+  describe('update failure', () => {
+    test
+      .stderr()
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => {
+        api
+          .post('/api/v2/guide/theming/jobs/themes/updates')
+          .reply(400, {
+            errors: [{
+              code: 'TooManyThemes',
+              title: 'Maximum number of allowed themes reached'
+            }]
+          })
+      })
+      .it('should report errors when creating the update job fails', async (ctx) => {
+        try {
+          await UpdateCommand.run([baseThemePath, '--themeId', '1234'])
+        } catch (error) {
+          expect(ctx.stderr).to.contain('!')
+          expect(error.message).to.contain('TooManyThemes')
+          expect(error.message).to.contain('Maximum number of allowed themes reached')
+        } finally {
+          nock.cleanAll()
+        }
+      })
+
+    test
+      .env({
+        ZENDESK_SUBDOMAIN: 'z3ntest',
+        ZENDESK_EMAIL: 'admin@z3ntest.com',
+        ZENDESK_PASSWORD: '123456' // the universal password
+      })
+      .nock('https://z3ntest.zendesk.com', api => {
+        api
+          .post('/api/v2/guide/theming/jobs/themes/updates')
+          .reply(202, { job })
+
+        api
+          .get('/api/v2/guide/theming/jobs/9999')
+          .reply(200, {
+            job: {
+              ...job,
+              status: 'failed',
+              data: null,
+              errors: [
+                {
+                  message: 'Template(s) with syntax error(s)',
+                  code: 'InvalidTemplates',
+                  meta: {
+                    'templates/new_request_page.hbs': [
+                      {
+                        description: "'request_fosrm' does not exist",
+                        line: 22,
+                        column: 6,
+                        length: 10
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          })
+      })
+      .nock('https://s3.com', (api) => {
+        api
+          .post('/upload/path')
+          .reply(200)
+      })
+      .it('should report validation errors', async (ctx) => {
+        try {
+          await UpdateCommand.run([baseThemePath, '--themeId', '1111'])
+        } catch (error) {
+          expect(error.message).to.contain('InvalidTemplates')
+          expect(error.message).to.contain('Template(s) with syntax error(s)')
+          expect(error.message).to.contain('Validation error')
+          expect(error.message).to.contain("'request_fosrm' does not exist")
+        } finally {
+          nock.cleanAll()
+        }
+      })
+  })
+})


### PR DESCRIPTION
Adding a new `zcli themes:update` command to update a previously imported theme.

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`405e93c`](https://github.com/zendesk/zcli/pull/182/commits/405e93cb7a2446f6f372dc2539797f63661490ed) Adding a createThemeUpdateJob module



### [`5b1c4e9`](https://github.com/zendesk/zcli/pull/182/commits/5b1c4e97539e8b97bcb562e85955c0fd35b77b2d) feat: adding support for zcli:themes update



### [`c38d2fb`](https://github.com/zendesk/zcli/pull/182/commits/c38d2fb44bd57faf0e701af5640f372a6f67d849) Documenting zcli:themes update command



### [`1146b45`](https://github.com/zendesk/zcli/pull/182/commits/1146b45fa8ea41e10a2fd6877bfd63d4ee59ce50) Apply suggestions from code review

Co-authored-by: André Alves <aalves@zendesk.com>

### [`8b0ef25`](https://github.com/zendesk/zcli/pull/182/commits/8b0ef2509148c69fd6bd959e8c41ab865d6eb992) Adding missing example



### [`19aeab5`](https://github.com/zendesk/zcli/pull/182/commits/19aeab53b8630ef839a5566e8edea718d3475243) Update docs/themes.md

Co-authored-by: André Alves <aalves@zendesk.com>

<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
