### PR TITLE
Fix preview

### DIFF
--- a/packages/zcli-themes/src/lib/zass.test.ts
+++ b/packages/zcli-themes/src/lib/zass.test.ts
@@ -41,7 +41,7 @@ describe('zass', () => {
           color: pink;
           font: Verdana;
           width: 100px;
-          background: url("http://localhost:1000/guide/assets/background.png");
+          background: url(http://localhost:1000/guide/assets/background.png);
         }
       `))
     })
@@ -50,25 +50,25 @@ describe('zass', () => {
   describe('darken', () => {
     it('replaces color with 6 hex digits', () => {
       expect(minify(zass('div { background-color: darken( #ff33cc, 10% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: #ff00bf; }
+        div { background-color: #ff00bf }
       `))
     })
 
     it('replaces color with 3 hex digits', () => {
       expect(minify(zass('div { background-color: darken( #ff5, 10% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: #ffff22; }
+        div { background-color: #ff2 }
       `))
     })
 
     it('replaces color with rgb format', () => {
       expect(minify(zass('div { background-color: darken( rgb(255, 1, 2), 10% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: #cd0001; }
+        div { background-color: #cd0001 }
       `))
     })
 
     it('replaces color with hsla format', () => {
       expect(minify(zass('div { background-color: darken( hsla(180, 50%, 50%, 0.2), 20% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: rgba(38, 115, 115, 0.2); }
+        div { background-color: rgba(38, 115, 115, .2) }
       `))
     })
 
@@ -78,7 +78,7 @@ describe('zass', () => {
         [{ identifier: 'cool_color', type: 'color', value: '#ff33cc' }],
         []
       ))).to.deep.equal(minify(`
-        div { background-color: #ff00bf; }
+        div { background-color: #ff00bf }
       `))
     })
   })
@@ -86,25 +86,25 @@ describe('zass', () => {
   describe('lighten', () => {
     it('replaces color with 6 hex digits', () => {
       expect(minify(zass('div { background-color: lighten( #5566ff, 10% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: #8894ff; }
+        div { background-color: #8894ff }
       `))
     })
 
     it('replaces color with 3 hex digits', () => {
       expect(minify(zass('div { background-color: lighten( #55d, 10% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: #8080e6; }
+        div { background-color: #8080e6 }
       `))
     })
 
     it('replaces color with rgb format', () => {
       expect(minify(zass('div { background-color: lighten( rgb(255, 1, 2), 10% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: #ff3435; }`
+        div { background-color: #ff3435 }`
       ))
     })
 
     it('replaces color with hsla format', () => {
       expect(minify(zass('div { background-color: lighten( hsla(180, 50%, 50%, 0.2), 20% ) }', [], []))).to.deep.equal(minify(`
-        div { background-color: rgba(140, 217, 217, 0.2); }
+        div { background-color: rgba(140, 217, 217, .2) }
       `))
     })
 
@@ -114,7 +114,7 @@ describe('zass', () => {
         [{ identifier: 'cool_color', type: 'color', value: '#5566ff' }],
         [])
       )).to.deep.equal(minify(`
-        div { background-color: #8894ff; }
+        div { background-color: #8894ff }
       `))
     })
   })

--- a/packages/zcli-themes/src/lib/zass.ts
+++ b/packages/zcli-themes/src/lib/zass.ts
@@ -8,40 +8,55 @@ import * as sass from 'sass'
 // https://support.zendesk.com/hc/en-us/articles/4408846524954-Customizing-the-Settings-panel#using-settings-in-manifest-json-as-variables
 // Apart from variable syntax, we also also support 'lighten' and 'darken' functions
 export default function zass (source: string, variables: Variable[], assets: [path.ParsedPath, string][]) {
-  let output
+  let output = source
 
-  try {
-    // Escape theme variables and supported functions
-    const escaped = source
-      .replace(/\$/g, '\\$') // escape variables
-      .replace(/lighten/g, '\\\\lighten') // escape 'lighten' function
-      .replace(/darken/g, '\\\\darken') // escape 'darken' function
+  const replacements: Record<Variable['identifier'], Variable['value']> = {}
+  const identifiers = variables.map(({ identifier }) => identifier)
 
-    // Validate CSS does not include unsupported SASS features
-    output = sass.compileString(escaped, {
-      // syntax: 'css' is plain CSS, which is parsed like SCSS but forbids the use of any special Sass features:
-      // https://sass-lang.com/documentation/js-api/modules#Syntax
-      syntax: 'css'
-    })
-  } catch {
-    // not supported
-    output = source
-  } finally {
-    // safe to compile as SCSS
-    const manifestVariable = variables
-      .map((variable) => `$${variable.identifier}: ${variable.type === 'file' ? `"${variable.value}"` : variable.value};`)
-      .join('\n')
-
-    const assetVariables = assets.map(([parsedPath, url]) => {
-      const name = parsedPath.name.replace(/\+/g, '-')
-      const extension = parsedPath.ext.split('.').pop()
-      return `$assets-${name}-${extension}: "${url}";`
-    }).join('\n')
-
-    output = sass.compileString(manifestVariable + assetVariables + source, {
-      syntax: 'scss'
-    }).css
+  // variables from settings in the `manifest.json` file
+  for (const { identifier, value } of variables) {
+    replacements[`$${identifier}`] = value // suport default variable sytax, e.g. `$name`
+    replacements[`#{$${identifier}}`] = value // suport (undocumented) interpolation, e.g. `#{$name}`
   }
+
+  // variables from files in the `assets` folder
+  for (const [parsedPath, url] of assets) {
+    const name = parsedPath.name.replace(/\+/g, '-')
+    const extension = parsedPath.ext.split('.').pop()
+    const identifier = `assets-${name}-${extension}`
+    replacements[`$${identifier}`] = url
+    // make sure to add all asset identifiers before
+    // composing the regular expression
+    identifiers.push(identifier)
+  }
+
+  const groups = `(${identifiers.join('|')})`
+  const variablesRegex = new RegExp(`(\\$${groups}\\b)|(#\\{\\$${groups}\\})`, 'g')
+
+  // First replace all variables and interpolated variables
+  output = output.replace(variablesRegex, (match) => {
+    return (replacements[match] || match).toString()
+  })
+
+  const command = /(?<command>lighten|darken)/i
+  const percentage = /(?<percentage>\d{1,3})%/
+  const functionsRegex = new RegExp(`${command.source}\\s*\\((?<color>.*),\\s*${percentage.source}\\s*\\)`)
+
+  // `darken` and `lighten` functions may use variables so make
+  // sure to replace them last
+  output = output.replace(functionsRegex, (match/*, command, color, percentage */) => {
+    const prefix = 'code{color:'
+    const suffix = '}'
+
+    // dart-sass does not provide an api to individually compile `darken` and `lighten`
+    // so we improvise one using `compileString` with a valid SCSS string.
+    // If such an api ever becomes available, we could switch to using it along with
+    // the named gorups "command", "color" and "percentage"
+    const compiled = sass.compileString(prefix + match + suffix, { style: 'compressed' }).css
+    const value = compiled.substring(prefix.length, compiled.length - suffix.length)
+
+    return value
+  })
 
   return output
 }

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -45,8 +45,8 @@ describe('themes:preview', function () {
       .it('should serve a compiled stylesheet', async () => {
         const stylesheet = (await axios.get('http://0.0.0.0:9999/guide/style.css')).data
         expect(stylesheet).to.contain('color: #17494D;')
-        expect(stylesheet).to.contain('background: url("http://0.0.0.0:9999/guide/settings/logo.png");')
-        expect(stylesheet).to.contain('cursor: url("http://0.0.0.0:9999/guide/assets/bike.png"), pointer;')
+        expect(stylesheet).to.contain('background: url(http://0.0.0.0:9999/guide/settings/logo.png);')
+        expect(stylesheet).to.contain('cursor: url(http://0.0.0.0:9999/guide/assets/bike.png), pointer;')
         expect(stylesheet).to.contain('width: 12px;')
       })
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR reimplements the zass formatter to be as close as a 1:1 match with the zass formatter in ZAT as possible.

*Context:*

We initially tried to simplify and have a fully `sass` based implementation of the zass formatter. However, that led to a few inconsistencies in the output, and it also led to a few problems with SASS [compilation errors](https://github.com/zendesk/zcli/issues/177#issuecomment-1574284189). 
ZAT basically just works based on find and replace so I ported that implementation over. It should also addressed the issue linked above.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`95524b7`](https://github.com/zendesk/zcli/pull/186/commits/95524b7fd00a8183d5cc7d4d1153ec0509a46702) Reimplement preview to be backwards compatible with ZAT



### [`6909e4d`](https://github.com/zendesk/zcli/pull/186/commits/6909e4d8854796de01c7de15cc252ec5fae156e2) Update preview unit tests



### [`0fa6e0f`](https://github.com/zendesk/zcli/pull/186/commits/0fa6e0f4cb0fac4844d3b950c44c6e88102e135f) Update preview functional tests



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
