### PR TITLE
Add themes to docs + CI caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
             ./packages/zcli/node_modules/
             ./packages/zcli-core/node_modules/
             ./packages/zcli-apps/node_modules/
+            ./packages/zcli-themes/node_modules/
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/package.json') }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             node-modules-${{ runner.os }}-${{ hashFiles('**/package.json') }}-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version](https://badge.fury.io/js/%40zendesk%2Fzcli.svg)](https://www.npmjs.com/package/@zendesk/zcli)
 ![Test](https://github.com/zendesk/zcli/workflows/Test/badge.svg)
 
-ZCLI is a Zendesk CLI which helps you build and manage your Zendesk apps from the command line. ZCLI is currently available in beta and is built using the [oclif](https://github.com/oclif/oclif) framework.
+ZCLI is a Zendesk CLI which helps you build and manage your Zendesk apps and themes from the command line. ZCLI is currently available in beta and is built using the [oclif](https://github.com/oclif/oclif) framework.
 
 <img src="demo.gif" alt="Zendesk Logo" />
 
@@ -50,6 +50,7 @@ A better approach might be to await the upcoming support for GUI apps in WSL2 th
 ZCLI supports numerous commands. Further documentation on available commands can be found [here.](/docs)
 
 - [`$ zcli apps`](/docs/apps.md) - manage zendesk apps workflow.
+- [`$ zcli themes`](/docs/themes.md) - manage zendesk themes workflow.
 - [`$ zcli profiles`](/docs/profiles.md) - manage zcli profiles.
 - [`$ zcli login`](/docs/login.md) - login to zendesk account.
 - [`$ zcli logout`](/docs/logout.md) - logout and remove active profile.

--- a/packages/zcli/README.md
+++ b/packages/zcli/README.md
@@ -14,6 +14,7 @@ USAGE
 # Command Topics
 
 * [`zcli apps`](../../docs/apps.md) - manage Zendesk apps workflow
+* [`zcli themes`](../../docs/themes.md) - manage Zendesk themes workflow
 * [`zcli autocomplete`](../../docs/autocomplete.md) - display autocomplete installation instructions
 * [`zcli help`](../../docs/help.md) - display help for zcli
 * [`zcli login`](../../docs/login.md) - creates and/or saves an authentication token for the specified subdomain


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR:
- Updates docs to include themes;
- Updates CI to cache theme dependencies;

## Checklist

- [ ] :guardsman: includes new unit and functional tests
