### PR TITLE
fix: template identifier matching issue on Windows

### DIFF
--- a/packages/zcli-themes/src/lib/getTemplates.ts
+++ b/packages/zcli-themes/src/lib/getTemplates.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 
 export default function getTemplates (themePath: string): Record<string, string> {
   const templates: Record<string, string> = {}
-  const filenames = globSync(`${themePath}/templates/**/*.hbs`)
+  const filenames = globSync(`${themePath}/templates/**/*.hbs`, { posix: true })
 
   filenames.forEach((template) => {
     const identifier = template.split('templates/')[1].split('.hbs')[0]


### PR DESCRIPTION
## Description

On Windows, the `globSync` function returns the `\\` path separator by default. However, we are matching against a posix path separator of `/` as can be seen on line 9's split pattern of `template.split('templates/')`. This is causing the following error:
```
TypeError: Cannot read properties of undefined (reading 'split')
```

This PR explicitly instructs glob to return path results using posix path separators and allows the split pattern to match correctly.