### PR TITLE
fix: fixed brand id getter when only one brand is present

### DIFF
--- a/packages/zcli-themes/src/lib/getBrandId.test.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.test.ts
@@ -17,7 +17,7 @@ describe('getBrandId', () => {
     requestStub.returns(Promise.resolve({
       data: {
         brands: [{
-          id: '1234'
+          id: 1234
         }]
       }
     }) as axios.AxiosPromise)
@@ -34,8 +34,8 @@ describe('getBrandId', () => {
     requestStub.returns(Promise.resolve({
       data: {
         brands: [
-          { id: '1111', name: 'Brand 1' },
-          { id: '2222', name: 'Brand 2' }
+          { id: 1111, name: 'Brand 1' },
+          { id: 2222, name: 'Brand 2' }
         ]
       }
     }) as axios.AxiosPromise)

--- a/packages/zcli-themes/src/lib/getBrandId.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.ts
@@ -10,7 +10,7 @@ export default async function getBrandId (): Promise<string> {
     })
 
     if (brands.length === 1) {
-      return brands[0].id
+      return brands[0].id.toString()
     }
 
     const { brandId } = await inquirer.prompt({


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
The method used in the themes command for getting the brands was failing when the account has only one brand, since the API returns an integer and we were converting it to string only in the case of multiple brands available.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`d611dc7`](https://github.com/zendesk/zcli/pull/195/commits/d611dc74f4b4738e86056e983bdc31d3cbfb2ecb) fix: fixed brand id getter when only one brand is present



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
