### PR TITLE
feat: support `themes:list` and `themes:delete` commands

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -51,7 +51,7 @@ OPTIONS
 
 EXAMPLES
   $ zcli themes:import ./copenhagen_theme
-  $ zcli themes:import ./copenhagen_theme --brandId=123456789100
+  $ zcli themes:import ./copenhagen_theme --brandId=123456
 ```
 
 ## `zcli themes:update [THEMEDIRECTORY]`

--- a/packages/zcli-themes/src/commands/themes/delete.ts
+++ b/packages/zcli-themes/src/commands/themes/delete.ts
@@ -1,0 +1,42 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import { request } from '@zendesk/zcli-core'
+import * as chalk from 'chalk'
+
+export default class Delete extends Command {
+  static description = 'delete a theme'
+
+  static enableJsonFlag = true
+
+  static flags = {
+    themeId: Flags.string({ description: 'The id of the theme to delete' })
+  }
+
+  static examples = [
+    '$ zcli themes:delete --themeId=abcd'
+  ]
+
+  static strict = false
+
+  async run () {
+    let { flags: { themeId } } = await this.parse(Delete)
+
+    themeId = themeId || await CliUx.ux.prompt('Theme ID')
+
+    try {
+      CliUx.ux.action.start('Deleting theme')
+      await request.requestAPI(`/api/v2/guide/theming/themes/${themeId}`, {
+        method: 'delete',
+        headers: {
+          'X-Zendesk-Request-Originator': 'zcli themes:delete'
+        },
+        validateStatus: (status: number) => status === 204
+      })
+      CliUx.ux.action.stop('Ok')
+      this.log(chalk.green('Theme deleted successfully'), `theme ID: ${themeId}`)
+      return { themeId }
+    } catch (e: any) {
+      const [error] = e.response.data.errors
+      this.error(`${error.code} - ${error.title}`)
+    }
+  }
+}

--- a/packages/zcli-themes/src/commands/themes/import.ts
+++ b/packages/zcli-themes/src/commands/themes/import.ts
@@ -10,6 +10,8 @@ import pollJobStatus from '../../lib/pollJobStatus'
 export default class Import extends Command {
   static description = 'import a theme'
 
+  static enableJsonFlag = true
+
   static flags = {
     brandId: Flags.string({ description: 'The id of the brand where the theme should be imported to' })
   }
@@ -20,7 +22,7 @@ export default class Import extends Command {
 
   static examples = [
     '$ zcli themes:import ./copenhagen_theme',
-    '$ zcli themes:import ./copenhagen_theme --brandId=123456789100'
+    '$ zcli themes:import ./copenhagen_theme --brandId=123456'
   ]
 
   static strict = false
@@ -42,6 +44,10 @@ export default class Import extends Command {
 
     await pollJobStatus(themePath, job.id)
 
-    this.log(chalk.green('Theme imported successfully'), `theme ID: ${job.data.theme_id}`)
+    const themeId = job.data.theme_id
+
+    this.log(chalk.green('Theme imported successfully'), `theme ID: ${themeId}`)
+
+    return { themeId }
   }
 }

--- a/packages/zcli-themes/src/commands/themes/list.ts
+++ b/packages/zcli-themes/src/commands/themes/list.ts
@@ -1,0 +1,42 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import { request } from '@zendesk/zcli-core'
+import * as chalk from 'chalk'
+import getBrandId from '../../lib/getBrandId'
+
+export default class List extends Command {
+  static description = 'list installed themes'
+
+  static enableJsonFlag = true
+
+  static flags = {
+    brandId: Flags.string({ description: 'The id of the brand where the themes are installed' })
+  }
+
+  static examples = [
+    '$ zcli themes:list --brandId=123456'
+  ]
+
+  static strict = false
+
+  async run () {
+    let { flags: { brandId } } = await this.parse(List)
+
+    brandId = brandId || await getBrandId()
+
+    try {
+      CliUx.ux.action.start('Listing themes')
+      const { data: { themes } } = await request.requestAPI(`/api/v2/guide/theming/themes?brand_id=${brandId}`, {
+        headers: {
+          'X-Zendesk-Request-Originator': 'zcli themes:list'
+        },
+        validateStatus: (status: number) => status === 200
+      })
+      CliUx.ux.action.stop('Ok')
+      this.log(chalk.green('Themes listed successfully'), themes)
+      return { themes }
+    } catch (e: any) {
+      const [error] = e.response.data.errors
+      this.error(`${error.code} - ${error.title}`)
+    }
+  }
+}

--- a/packages/zcli-themes/src/commands/themes/publish.ts
+++ b/packages/zcli-themes/src/commands/themes/publish.ts
@@ -5,6 +5,8 @@ import * as chalk from 'chalk'
 export default class Publish extends Command {
   static description = 'publish a theme'
 
+  static enableJsonFlag = true
+
   static flags = {
     themeId: Flags.string({ description: 'The id of the theme to publish' })
   }
@@ -31,6 +33,7 @@ export default class Publish extends Command {
       })
       CliUx.ux.action.stop('Ok')
       this.log(chalk.green('Theme published successfully'), `theme ID: ${themeId}`)
+      return { themeId }
     } catch (e: any) {
       const [error] = e.response.data.errors
       this.error(`${error.code} - ${error.title}`)

--- a/packages/zcli-themes/src/commands/themes/update.ts
+++ b/packages/zcli-themes/src/commands/themes/update.ts
@@ -7,7 +7,9 @@ import uploadThemePackage from '../../lib/uploadThemePackage'
 import pollJobStatus from '../../lib/pollJobStatus'
 
 export default class Update extends Command {
-  static description = 'import a theme'
+  static description = 'update a theme'
+
+  static enableJsonFlag = true
 
   static flags = {
     themeId: Flags.string({ description: 'The id of the theme to update' }),
@@ -43,5 +45,7 @@ export default class Update extends Command {
     await pollJobStatus(themePath, job.id)
 
     this.log(chalk.green('Theme updated successfully'))
+
+    return { themeId }
   }
 }

--- a/packages/zcli-themes/tests/functional/delete.test.ts
+++ b/packages/zcli-themes/tests/functional/delete.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@oclif/test'
+import DeleteCommand from '../../src/commands/themes/delete'
+import env from './env'
+
+describe('themes:delete', function () {
+  describe('successful deletion', () => {
+    const success = test
+      .env(env)
+      .nock('https://z3ntest.zendesk.com', api => api
+        .delete('/api/v2/guide/theming/themes/1234')
+        .reply(204))
+
+    success
+      .stdout()
+      .it('should display success message when the theme is deleted successfully', async ctx => {
+        await DeleteCommand.run(['--themeId', '1234'])
+        expect(ctx.stdout).to.contain('Theme deleted successfully theme ID: 1234')
+      })
+
+    success
+      .stdout()
+      .it('should return an object containing the theme ID when ran with --json', async ctx => {
+        await DeleteCommand.run(['--themeId', '1234', '--json'])
+        expect(ctx.stdout).to.equal(JSON.stringify({ themeId: '1234' }, null, 2) + '\n')
+      })
+  })
+
+  describe('delete failure', () => {
+    test
+      .env(env)
+      .nock('https://z3ntest.zendesk.com', api => api
+        .delete('/api/v2/guide/theming/themes/1234')
+        .reply(400, {
+          errors: [{
+            code: 'ThemeNotFound',
+            title: 'Invalid id'
+          }]
+        }))
+      .stderr()
+      .it('should report delete errors', async ctx => {
+        try {
+          await DeleteCommand.run(['--themeId', '1234'])
+        } catch (error) {
+          expect(ctx.stderr).to.contain('!')
+          expect(error.message).to.contain('ThemeNotFound - Invalid id')
+        }
+      })
+  })
+})

--- a/packages/zcli-themes/tests/functional/env.ts
+++ b/packages/zcli-themes/tests/functional/env.ts
@@ -1,0 +1,5 @@
+export default {
+  ZENDESK_SUBDOMAIN: 'z3ntest',
+  ZENDESK_EMAIL: 'admin@z3ntest.com',
+  ZENDESK_PASSWORD: '123456' // the universal password
+}

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@oclif/test'
 import * as path from 'path'
 import * as nock from 'nock'
 import ImportCommand from '../../src/commands/themes/import'
+import env from './env'
 
 describe('themes:import', function () {
   const baseThemePath = path.join(__dirname, 'mocks/base_theme')
@@ -19,12 +20,8 @@ describe('themes:import', function () {
   }
 
   describe('successful import', () => {
-    test
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+    const success = test
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => {
         api
           .post('/api/v2/guide/theming/jobs/themes/imports')
@@ -39,21 +36,26 @@ describe('themes:import', function () {
           .post('/upload/path')
           .reply(200)
       })
+
+    success
       .stdout()
       .it('should display success message when the theme is imported successfully', async ctx => {
         await ImportCommand.run([baseThemePath, '--brandId', '1111'])
         expect(ctx.stdout).to.contain('Theme imported successfully theme ID: 1234')
+      })
+
+    success
+      .stdout()
+      .it('should return an object containing the theme ID when ran with --json', async ctx => {
+        await ImportCommand.run([baseThemePath, '--brandId', '1111', '--json'])
+        expect(ctx.stdout).to.equal(JSON.stringify({ themeId: '1234' }, null, 2) + '\n')
       })
   })
 
   describe('import failure', () => {
     test
       .stderr()
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => {
         api
           .post('/api/v2/guide/theming/jobs/themes/imports')
@@ -77,11 +79,7 @@ describe('themes:import', function () {
       })
 
     test
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => {
         api
           .post('/api/v2/guide/theming/jobs/themes/imports')

--- a/packages/zcli-themes/tests/functional/list.test.ts
+++ b/packages/zcli-themes/tests/functional/list.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@oclif/test'
+import ListCommand from '../../src/commands/themes/list'
+import env from './env'
+
+describe('themes:list', function () {
+  describe('successful list', () => {
+    const success = test
+      .env(env)
+      .nock('https://z3ntest.zendesk.com', api => api
+        .get('/api/v2/guide/theming/themes?brand_id=1111')
+        .reply(200, { themes: [] }))
+
+    success
+      .stdout()
+      .it('should display success message when thes themes are listed successfully', async ctx => {
+        await ListCommand.run(['--brandId', '1111'])
+        expect(ctx.stdout).to.contain('Themes listed successfully []')
+      })
+
+    success
+      .stdout()
+      .it('should return an object containing the theme ID when ran with --json', async ctx => {
+        await ListCommand.run(['--brandId', '1111', '--json'])
+        expect(ctx.stdout).to.equal(JSON.stringify({ themes: [] }, null, 2) + '\n')
+      })
+  })
+
+  describe('list failure', () => {
+    test
+      .env(env)
+      .nock('https://z3ntest.zendesk.com', api => api
+        .get('/api/v2/guide/theming/themes?brand_id=1111')
+        .reply(500, {
+          errors: [{
+            code: 'InternalError',
+            title: 'Something went wrong'
+          }]
+        }))
+      .stderr()
+      .it('should report publish errors', async ctx => {
+        try {
+          await ListCommand.run(['--brandId', '1111'])
+        } catch (error) {
+          expect(ctx.stderr).to.contain('!')
+          expect(error.message).to.contain('InternalError - Something went wrong')
+        }
+      })
+  })
+})

--- a/packages/zcli-themes/tests/functional/publish.test.ts
+++ b/packages/zcli-themes/tests/functional/publish.test.ts
@@ -1,31 +1,33 @@
 import { expect, test } from '@oclif/test'
 import PublishCommand from '../../src/commands/themes/publish'
+import env from './env'
 
 describe('themes:publish', function () {
   describe('successful publish', () => {
-    test
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+    const success = test
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => api
         .post('/api/v2/guide/theming/themes/1234/publish')
         .reply(200))
+
+    success
       .stdout()
       .it('should display success message when the theme is published successfully', async ctx => {
         await PublishCommand.run(['--themeId', '1234'])
         expect(ctx.stdout).to.contain('Theme published successfully theme ID: 1234')
       })
+
+    success
+      .stdout()
+      .it('should return an object containing the theme ID when ran with --json', async ctx => {
+        await PublishCommand.run(['--themeId', '1234', '--json'])
+        expect(ctx.stdout).to.equal(JSON.stringify({ themeId: '1234' }, null, 2) + '\n')
+      })
   })
 
   describe('publish failure', () => {
     test
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => api
         .post('/api/v2/guide/theming/themes/1234/publish')
         .reply(400, {

--- a/packages/zcli-themes/tests/functional/update.test.ts
+++ b/packages/zcli-themes/tests/functional/update.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@oclif/test'
 import * as path from 'path'
 import * as nock from 'nock'
 import UpdateCommand from '../../src/commands/themes/update'
+import env from './env'
 
 describe('themes:update', function () {
   const baseThemePath = path.join(__dirname, 'mocks/base_theme')
@@ -19,12 +20,8 @@ describe('themes:update', function () {
   }
 
   describe('successful update', () => {
-    test
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+    const success = test
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => {
         api
           .post('/api/v2/guide/theming/jobs/themes/updates')
@@ -39,21 +36,26 @@ describe('themes:update', function () {
           .post('/upload/path')
           .reply(200)
       })
+
+    success
       .stdout()
       .it('should display success message when the theme is updated successfully', async ctx => {
         await UpdateCommand.run([baseThemePath, '--themeId', '1234'])
         expect(ctx.stdout).to.contain('Theme updated successfully')
+      })
+
+    success
+      .stdout()
+      .it('should return an object containing the theme ID when ran with --json', async ctx => {
+        await UpdateCommand.run([baseThemePath, '--themeId', '1234', '--json'])
+        expect(ctx.stdout).to.equal(JSON.stringify({ themeId: '1234' }, null, 2) + '\n')
       })
   })
 
   describe('update failure', () => {
     test
       .stderr()
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => {
         api
           .post('/api/v2/guide/theming/jobs/themes/updates')
@@ -77,11 +79,7 @@ describe('themes:update', function () {
       })
 
     test
-      .env({
-        ZENDESK_SUBDOMAIN: 'z3ntest',
-        ZENDESK_EMAIL: 'admin@z3ntest.com',
-        ZENDESK_PASSWORD: '123456' // the universal password
-      })
+      .env(env)
       .nock('https://z3ntest.zendesk.com', api => {
         api
           .post('/api/v2/guide/theming/jobs/themes/updates')


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

- [x] All commands now return json when ran with the `--json` flags (useful in CI)
- [x] Support for `themes:list`
- [x] Support for `themes:delete`

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`cd49d29`](https://github.com/zendesk/zcli/pull/198/commits/cd49d29a47a48379269a17865dee2b78be5f6b69) feat: return json in import, update and publish



### [`52d8fd7`](https://github.com/zendesk/zcli/pull/198/commits/52d8fd7f22383e5a5f91e3472191a97d9759c1a7) feat: adding a themes list command



### [`375011d`](https://github.com/zendesk/zcli/pull/198/commits/375011d6e8e9ee8ab7f61671241039b110fd30f9) feat: adding a themes delete command



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
