### PR TITLE
fix: fixed imports for getAccount and getProfileAccount

### DIFF
--- a/packages/zcli-core/src/index.ts
+++ b/packages/zcli-core/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Auth } from './lib/auth'
+export { getAccount, getProfileFromAccount } from './lib/authUtils'
 export { default as Config } from './lib/config'
 export { default as SecureStore } from './lib/secureStore'
 export { getBaseUrl } from './lib/requestUtils'

--- a/packages/zcli/src/commands/login.ts
+++ b/packages/zcli/src/commands/login.ts
@@ -1,8 +1,7 @@
 import { Command, Flags } from '@oclif/core'
 import * as chalk from 'chalk'
-import { SecureStore, Auth } from '@zendesk/zcli-core'
+import { SecureStore, Auth, getAccount } from '@zendesk/zcli-core'
 import { HELP_ENV_VARS } from '../utils/helpMessage'
-import { getAccount } from '@zendesk/zcli-core/src/lib/authUtils'
 
 export default class Login extends Command {
   static description = 'creates and/or saves an authentication token for the specified subdomain'

--- a/packages/zcli/src/commands/profiles/list.ts
+++ b/packages/zcli/src/commands/profiles/list.ts
@@ -1,9 +1,8 @@
 import { Command, CliUx } from '@oclif/core'
 import * as chalk from 'chalk'
-import { Auth, SecureStore } from '@zendesk/zcli-core'
+import { Auth, SecureStore, getAccount } from '@zendesk/zcli-core'
 import { Credential, Profile } from '@zendesk/zcli-core/src/types'
 import { HELP_ENV_VARS } from '../../utils/helpMessage'
-import { getAccount } from '@zendesk/zcli-core/src/lib/authUtils'
 
 export default class List extends Command {
   static description = 'lists all the profiles'

--- a/packages/zcli/src/commands/profiles/use.ts
+++ b/packages/zcli/src/commands/profiles/use.ts
@@ -1,8 +1,7 @@
 import { Command } from '@oclif/core'
 import * as chalk from 'chalk'
-import { SecureStore, Auth } from '@zendesk/zcli-core'
+import { SecureStore, Auth, getProfileFromAccount } from '@zendesk/zcli-core'
 import { HELP_ENV_VARS } from '../../utils/helpMessage'
-import { getProfileFromAccount } from '@zendesk/zcli-core/src/lib/authUtils'
 
 export default class Remove extends Command {
   static description = 'switches to a profile'


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR fixes some imports introduced in #196, which were pointing to source files and weren't working on the built package.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`f38c5d1`](https://github.com/zendesk/zcli/pull/199/commits/f38c5d1a28ecadb51596de2b5c65f3247e382a91) fix: fixed imports for getAccount and getProfileAccount



<!-- === GH HISTORY FENCE === -->
