### PR TITLE
feat(themes): Added options for starting the preview mode in HTTPS

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -28,31 +28,31 @@ OPTIONS
   --port=port      [default: 4567] Port for the http server to use
   --logs           Tail logs
   --no-livereload  Disable live-reloading the preview when a change is made
-  --ssl-cert       SSL Certificate used to start the server in HTTPS mode
-  --ssl-key        SSL Key used to start the server in HTTPS mode
+  --https-cert     Certificate used to start the server in HTTPS mode
+  --https-key      Key used to start the server in HTTPS mode
 
 EXAMPLES
   $ zcli themes:preview ./copenhagen_theme
   $ zcli themes:preview ./copenhagen_theme --port=9999
   $ zcli themes:preview ./copenhagen_theme --no-livereload
-  $ zcli themes:preview ./copenhagen_theme --ssl-cert localhost.crt --ssl-key localhost.key
+  $ zcli themes:preview ./copenhagen_theme --https-cert localhost.crt --https-key localhost.key
 ```
 
-### Previewing in Safari
+### HTTPS
 When using the preview mode, you open your instance on `https://[subdomain].zendesk.com`, and all the theme assets are served from a local web server that runs by default on `http://localhost:4567`. An HTTPS page that includes content fetched using HTTP is called a mixed content page.
 
-Safari [doesn't allow mixed content for localhost](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_locally_delivered_mixed-resources). This means that when using the preview mode with the default settings, the connection to the local server is blocked by the browser. To avoid this issue you need to have an SSL certificate and an SSL Key for the local server and pass them to ZCLI using the `--ssl-cert` and `--ssl-key` options.
+Some browsers (like Safari) [don't allow mixed content for localhost](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_locally_delivered_mixed-resources). This means that when using the preview mode with the default settings, the connection to the local server is blocked by the browser. To avoid this issue you need to have an SSL certificate and an SSL Key for the local server and pass them to ZCLI using the `--https-cert` and `--https-key` options.
 
 One option is to use https://github.com/Upinel/localhost.direct, which provides a wildcard certificate for `*.localhost.direct`, and a DNS record that redirects `*.localhost.direct` to `localhost`. You just need to download the certificates and start the preview mode binding to a `localhost.direct` subdomain and passing the certificate files:
 
 ```
-zcli themes:preview --bind themes.localhost.direct --ssl-cert ~/localhost.direct.crt --ssl-key ~/localhost.direct.key
+zcli themes:preview --bind themes.localhost.direct --https-cert ~/localhost.direct.crt --https-key ~/localhost.direct.key
 ```
 
 Another option is to [create a self-signed certificate for localhost](https://letsencrypt.org/docs/certificates-for-localhost/#making-and-trusting-your-own-certificates). In this case, you need to create the certificate, trust it in the Mac OS System Keychain, and pass the required options to `zcli`:
 
 ```
-zcli themes:preview --ssl-cert ~/localhost.crt --ssl-key ~/localhost.key
+zcli themes:preview --https-cert ~/localhost.crt --https-key ~/localhost.key
 ```
 ## `zcli themes:import [THEMEDIRECTORY]`
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -28,13 +28,32 @@ OPTIONS
   --port=port      [default: 4567] Port for the http server to use
   --logs           Tail logs
   --no-livereload  Disable live-reloading the preview when a change is made
+  --ssl-cert       SSL Certificate used to start the server in HTTPS mode
+  --ssl-key        SSL Key used to start the server in HTTPS mode
 
 EXAMPLES
   $ zcli themes:preview ./copenhagen_theme
   $ zcli themes:preview ./copenhagen_theme --port=9999
   $ zcli themes:preview ./copenhagen_theme --no-livereload
+  $ zcli themes:preview ./copenhagen_theme --ssl-cert localhost.crt --ssl-key localhost.key
 ```
 
+### Previewing in Safari
+When using the preview mode, you open your instance on `https://[subdomain].zendesk.com`, and all the theme assets are served from a local web server that runs by default on `http://localhost:4567`. An HTTPS page that includes content fetched using HTTP is called a mixed content page.
+
+Safari [doesn't allow mixed content for localhost](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_locally_delivered_mixed-resources). This means that when using the preview mode with the default settings, the connection to the local server is blocked by the browser. To avoid this issue you need to have an SSL certificate and an SSL Key for the local server and pass them to ZCLI using the `--ssl-cert` and `--ssl-key` options.
+
+One option is to use https://github.com/Upinel/localhost.direct, which provides a wildcard certificate for `*.localhost.direct`, and a DNS record that redirects `*.localhost.direct` to `localhost`. You just need to download the certificates and start the preview mode binding to a `localhost.direct` subdomain and passing the certificate files:
+
+```
+zcli themes:preview --bind themes.localhost.direct --ssl-cert ~/localhost.direct.crt --ssl-key ~/localhost.direct.key
+```
+
+Another option is to [create a self-signed certificate for localhost](https://letsencrypt.org/docs/certificates-for-localhost/#making-and-trusting-your-own-certificates). In this case, you need to create the certificate, trust it in the Mac OS System Keychain, and pass the required options to `zcli`:
+
+```
+zcli themes:preview --ssl-cert ~/localhost.crt --ssl-key ~/localhost.key
+```
 ## `zcli themes:import [THEMEDIRECTORY]`
 
 imports a theme in your desired target account and brand

--- a/packages/zcli-themes/src/commands/themes/preview.ts
+++ b/packages/zcli-themes/src/commands/themes/preview.ts
@@ -28,8 +28,8 @@ export default class Preview extends Command {
     port: Flags.integer({ default: 4567, description: 'Port for the http server to use' }),
     logs: Flags.boolean({ default: false, description: 'Tail logs' }),
     livereload: Flags.boolean({ default: true, description: 'Enable or disable live-reloading the preview when a change is made', allowNo: true }),
-    'ssl-cert': Flags.file({ description: 'SSL Certificate used to start the server in HTTPS mode' }),
-    'ssl-key': Flags.file({ description: 'SSL Key used to start the server in HTTPS mode' })
+    'https-cert': Flags.file({ description: 'Certificate used to start the server in HTTPS mode' }),
+    'https-key': Flags.file({ description: 'Key used to start the server in HTTPS mode' })
   }
 
   static args = [
@@ -45,14 +45,14 @@ export default class Preview extends Command {
   async run () {
     const { flags, argv: [themeDirectory] } = await this.parse(Preview)
     const themePath = path.resolve(themeDirectory)
-    const { logs: tailLogs, bind: host, port, 'ssl-cert': sslCert, 'ssl-key': sslKey } = flags
+    const { logs: tailLogs, bind: host, port, 'https-cert': httpsCert, 'https-key': httpsKey } = flags
 
     let httpsServerOptions: https.ServerOptions | null = null
 
-    if (sslCert && sslKey) {
+    if (httpsCert && httpsKey) {
       httpsServerOptions = {
-        key: fs.readFileSync(sslKey),
-        cert: fs.readFileSync(sslCert)
+        key: fs.readFileSync(httpsKey),
+        cert: fs.readFileSync(httpsCert)
       }
     }
 

--- a/packages/zcli-themes/src/commands/themes/preview.ts
+++ b/packages/zcli-themes/src/commands/themes/preview.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as express from 'express'
 import * as http from 'http'
+import * as https from 'https'
 import * as WebSocket from 'ws'
 import * as morgan from 'morgan'
 import * as chalk from 'chalk'
@@ -26,7 +27,9 @@ export default class Preview extends Command {
     bind: Flags.string({ default: 'localhost', description: 'Bind theme server to a specific host' }),
     port: Flags.integer({ default: 4567, description: 'Port for the http server to use' }),
     logs: Flags.boolean({ default: false, description: 'Tail logs' }),
-    livereload: Flags.boolean({ default: true, description: 'Enable or disable live-reloading the preview when a change is made', allowNo: true })
+    livereload: Flags.boolean({ default: true, description: 'Enable or disable live-reloading the preview when a change is made', allowNo: true }),
+    'ssl-cert': Flags.file({ description: 'SSL Certificate used to start the server in HTTPS mode' }),
+    'ssl-key': Flags.file({ description: 'SSL Key used to start the server in HTTPS mode' })
   }
 
   static args = [
@@ -42,12 +45,21 @@ export default class Preview extends Command {
   async run () {
     const { flags, argv: [themeDirectory] } = await this.parse(Preview)
     const themePath = path.resolve(themeDirectory)
-    const { logs: tailLogs, bind: host, port } = flags
+    const { logs: tailLogs, bind: host, port, 'ssl-cert': sslCert, 'ssl-key': sslKey } = flags
+
+    let httpsServerOptions: https.ServerOptions | null = null
+
+    if (sslCert && sslKey) {
+      httpsServerOptions = {
+        key: fs.readFileSync(sslKey),
+        cert: fs.readFileSync(sslCert)
+      }
+    }
 
     await preview(themePath, flags)
 
     const app = express()
-    const server = http.createServer(app)
+    const server = httpsServerOptions === null ? http.createServer(app) : https.createServer(httpsServerOptions, app)
     const wss = new WebSocket.Server({ server, path: '/livereload' })
 
     app.use(cors())

--- a/packages/zcli-themes/src/lib/getAssets.ts
+++ b/packages/zcli-themes/src/lib/getAssets.ts
@@ -2,12 +2,12 @@ import type { Flags } from '../types'
 import { CLIError } from '@oclif/core/lib/errors'
 import * as fs from 'fs'
 import * as path from 'path'
+import { getLocalServerBaseUrl } from './getLocalServerBaseUrl'
 
 export default function getAssets (themePath: string, flags: Flags): [path.ParsedPath, string][] {
   const assetsPath = `${themePath}/assets`
   const filenames = fs.existsSync(assetsPath) ? fs.readdirSync(assetsPath) : []
   const assets: [path.ParsedPath, string][] = []
-  const { bind: host, port } = flags
 
   filenames.forEach(filename => {
     const parsedPath = path.parse(filename)
@@ -18,7 +18,7 @@ export default function getAssets (themePath: string, flags: Flags): [path.Parse
       )
     }
     if (!name.startsWith('.')) {
-      assets.push([parsedPath, `http://${host}:${port}/guide/assets/${filename}`])
+      assets.push([parsedPath, `${getLocalServerBaseUrl(flags)}/guide/assets/${filename}`])
     }
   })
 

--- a/packages/zcli-themes/src/lib/getLocalServerBaseUrl.test.ts
+++ b/packages/zcli-themes/src/lib/getLocalServerBaseUrl.test.ts
@@ -21,8 +21,8 @@ describe('getLocalServerBaseUrl', () => {
       port: 4567,
       logs: false,
       livereload: true,
-      'ssl-cert': 'localhost.crt',
-      'ssl-key': 'localhost.key'
+      'https-cert': 'localhost.crt',
+      'https-key': 'localhost.key'
     }
     const result = getLocalServerBaseUrl(flags)
     const expected = 'https://themes.local:4567'
@@ -47,8 +47,8 @@ describe('getLocalServerBaseUrl', () => {
       port: 4567,
       logs: false,
       livereload: true,
-      'ssl-cert': 'localhost.crt',
-      'ssl-key': 'localhost.key'
+      'https-cert': 'localhost.crt',
+      'https-key': 'localhost.key'
     }
     const result = getLocalServerBaseUrl(flags, true)
     const expected = 'wss://themes.local:4567'

--- a/packages/zcli-themes/src/lib/getLocalServerBaseUrl.test.ts
+++ b/packages/zcli-themes/src/lib/getLocalServerBaseUrl.test.ts
@@ -1,0 +1,57 @@
+import { expect } from '@oclif/test'
+import { Flags } from '../types'
+import { getLocalServerBaseUrl } from './getLocalServerBaseUrl'
+
+describe('getLocalServerBaseUrl', () => {
+  it('should return correct http url', () => {
+    const flags: Flags = {
+      bind: 'localhost',
+      port: 4567,
+      logs: false,
+      livereload: true
+    }
+    const result = getLocalServerBaseUrl(flags)
+    const expected = 'http://localhost:4567'
+    expect(result).to.equal(expected)
+  })
+
+  it('should return correct https url', () => {
+    const flags: Flags = {
+      bind: 'themes.local',
+      port: 4567,
+      logs: false,
+      livereload: true,
+      'ssl-cert': 'localhost.crt',
+      'ssl-key': 'localhost.key'
+    }
+    const result = getLocalServerBaseUrl(flags)
+    const expected = 'https://themes.local:4567'
+    expect(result).to.equal(expected)
+  })
+
+  it('should return correct ws url', () => {
+    const flags: Flags = {
+      bind: 'localhost',
+      port: 4567,
+      logs: false,
+      livereload: true
+    }
+    const result = getLocalServerBaseUrl(flags, true)
+    const expected = 'ws://localhost:4567'
+    expect(result).to.equal(expected)
+  })
+
+  it('should return correct wss url', () => {
+    const flags: Flags = {
+      bind: 'themes.local',
+      port: 4567,
+      logs: false,
+      livereload: true,
+      'ssl-cert': 'localhost.crt',
+      'ssl-key': 'localhost.key'
+    }
+    const result = getLocalServerBaseUrl(flags, true)
+    const expected = 'wss://themes.local:4567'
+    expect(result).to.equal(expected)
+  })
+})

--- a/packages/zcli-themes/src/lib/getLocalServerBaseUrl.ts
+++ b/packages/zcli-themes/src/lib/getLocalServerBaseUrl.ts
@@ -6,10 +6,10 @@ export function getLocalServerBaseUrl (flags: Flags, isWebsocket = false): strin
 }
 
 function getProtocol (flags: Flags, isWebsocket: boolean): string {
-  const { 'ssl-cert': sslCert, 'ssl-key': sslKey } = flags
+  const { 'https-cert': httpsCert, 'https-key': httpsKey } = flags
   if (isWebsocket) {
-    return sslCert && sslKey ? 'wss' : 'ws'
+    return httpsCert && httpsKey ? 'wss' : 'ws'
   } else {
-    return sslCert && sslKey ? 'https' : 'http'
+    return httpsCert && httpsKey ? 'https' : 'http'
   }
 }

--- a/packages/zcli-themes/src/lib/getLocalServerBaseUrl.ts
+++ b/packages/zcli-themes/src/lib/getLocalServerBaseUrl.ts
@@ -1,0 +1,15 @@
+import { Flags } from '../types'
+
+export function getLocalServerBaseUrl (flags: Flags, isWebsocket = false): string {
+  const { bind: host, port } = flags
+  return `${getProtocol(flags, isWebsocket)}://${host}:${port}`
+}
+
+function getProtocol (flags: Flags, isWebsocket: boolean): string {
+  const { 'ssl-cert': sslCert, 'ssl-key': sslKey } = flags
+  if (isWebsocket) {
+    return sslCert && sslKey ? 'wss' : 'ws'
+  } else {
+    return sslCert && sslKey ? 'https' : 'http'
+  }
+}

--- a/packages/zcli-themes/src/lib/getVariables.ts
+++ b/packages/zcli-themes/src/lib/getVariables.ts
@@ -2,11 +2,11 @@ import type { Setting, Variable, Flags } from '../types'
 import * as fs from 'fs'
 import * as path from 'path'
 import { CLIError } from '@oclif/core/lib/errors'
+import { getLocalServerBaseUrl } from './getLocalServerBaseUrl'
 
 export default function getVariables (themePath: string, settings: Setting[], flags: Flags): Variable[] {
   const settingsPath = `${themePath}/settings`
   const filenames = fs.existsSync(settingsPath) ? fs.readdirSync(settingsPath) : []
-  const { bind: host, port } = flags
 
   return settings
     .reduce((variables: Variable[], setting) => [...variables, ...setting.variables], [])
@@ -18,7 +18,7 @@ export default function getVariables (themePath: string, settings: Setting[], fl
             `The setting "${variable.identifier}" of type "file" does not have a matching file within the "settings" folder`
           )
         }
-        variable.value = file && `http://${host}:${port}/guide/settings/${file}`
+        variable.value = file && `${getLocalServerBaseUrl(flags)}/guide/settings/${file}`
       }
       return variable
     })

--- a/packages/zcli-themes/src/lib/preview.test.ts
+++ b/packages/zcli-themes/src/lib/preview.test.ts
@@ -84,7 +84,7 @@ describe('preview', () => {
             <link rel="stylesheet" href="http://localhost:1000/guide/style.css">
             <meta charset="utf-8">
             <script src="http://localhost:1000/guide/script.js"></script>
-            ${livereloadScript(flags.bind, flags.port)}
+            ${livereloadScript(flags)}
           `,
           assets: { 'background.png': 'http://localhost:1000/guide/assets/background.png' },
           variables: { color: '#999', logo: 'http://localhost:1000/guide/settings/logo.png' },

--- a/packages/zcli-themes/src/types.ts
+++ b/packages/zcli-themes/src/types.ts
@@ -4,8 +4,8 @@ export type Flags = {
   port: number,
   logs: boolean,
   livereload: boolean,
-  'ssl-key'?: string,
-  'ssl-cert'?: string
+  'https-key'?: string,
+  'https-cert'?: string
 }
 
 export type Variable = {

--- a/packages/zcli-themes/src/types.ts
+++ b/packages/zcli-themes/src/types.ts
@@ -4,6 +4,8 @@ export type Flags = {
   port: number,
   logs: boolean,
   livereload: boolean,
+  'ssl-key'?: string,
+  'ssl-cert'?: string
 }
 
 export type Variable = {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

This PR adds the `--https-cert` and `--https-key` options for the `themes:preview` command, used for serving the theme assets from an HTTPS connection. This is needed for using the preview mode with Safari, which [doesn't allow mixed content for localhost](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_locally_delivered_mixed-resources).

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`fcf7a88`](https://github.com/zendesk/zcli/pull/203/commits/fcf7a8830b2343fe586c7bb3c749fa0ee28acc5b) feat(themes): Added options for starting the preview mode in HTTPS



### [`9e37766`](https://github.com/zendesk/zcli/pull/203/commits/9e37766ccd5dc28337ebc00bfbb11545e1e9dcdd) chore(themes): renamed ssl preview options to https



<!-- === GH HISTORY FENCE === -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
