### PR TITLE
Fix(apps)/not update app config

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -148,6 +148,13 @@ updates an existing private app in the Zendesk products specified in the apps ma
 ```
 USAGE
   $ zcli apps:update APPDIRECTORIES
+
+OPTIONS
+  --not-update-setting           Does not update current app config on instance
+
+EXAMPLES
+  $ zcli apps:update
+  $ zcli apps:update --not-update-setting
 ```
 
 ## `zcli apps:validate APPDIRECTORY`


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
_I encountered the same issue detailed in #183. While executing zcli apps:update within a GitHub action, the CLI overwrote the app configurations set by my client. I believe a straightforward flag to prevent the execution of the API endpoint /api/${product}/apps/installations/${installation_id}.json would suffice in scenarios like mine. However, I'm open to further discussion._
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Do NOT write here! This section will be filled in by GitHub Action
automatically. If you don't want this, either remove the markers or write
outside the fences.
<!-- === GH HISTORY FENCE === -->

<!-- supporting details; screen shot, code, etc. -->

<!-- closes #183 -->

Resolves #183 

## Checklist

- [ ] :guardsman: includes new unit and functional tests
