### PR TITLE
fix: convert Windows paths to POSIX format

### DIFF
--- a/packages/zcli-themes/src/lib/getTemplates.ts
+++ b/packages/zcli-themes/src/lib/getTemplates.ts
@@ -3,10 +3,10 @@ import * as fs from 'fs'
 
 export default function getTemplates (themePath: string): Record<string, string> {
   const templates: Record<string, string> = {}
-  const filenames = globSync(`${themePath}/templates/**/*.hbs`)
+  const filenames = globSync(`${themePath}/templates/**/*.hbs`.replace(/\\/g, '/'))
 
   filenames.forEach((template) => {
-    const identifier = template.split('templates/')[1].split('.hbs')[0]
+    const identifier = template.replace(/\\/g, '/').split('templates/')[1].split('.hbs')[0]
     const source = fs.readFileSync(template, 'utf8')
     templates[identifier] = source
   })


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Fixes an issue on Windows where the template identifier incorrectly matches due to non-posix path separator being used, but posix path separators being expected.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Do NOT write here! This section will be filled in by GitHub Action
automatically. If you don't want this, either remove the markers or write
outside the fences.
<!-- === GH HISTORY FENCE === -->

## Detail

On Windows, the globSync function returns the \\ path separator by default. However, we are matching against a posix path separator of / as can be seen on line 9's split pattern of template.split('templates/'). This is causing the following error:

`TypeError: Cannot read properties of undefined (reading 'split')`

This PR converts Window paths to POSIX paths (by replacing \\ to /) for the inputs and the outputs of the globSync function without used the new posix option available from glob 10.1.0.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
