### PR TITLE
[VEG-bau] Improve error handling

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,7 +4,7 @@
     "package": "./package.json",
     "reporter": "spec",
     "slow": "75",
-    "timeout": "5000",
+    "timeout": "10000",
     "ui": "bdd",
     "watch-files": ["lib/**/*.js", "test/**/*.js"],
     "watch-ignore": ["lib/vendor"],

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -66,8 +66,10 @@ export default class New extends Command {
             const fsExtraError = err as FsExtraError
             if (fsExtraError.code === 'ENOENT') {
               reject(new Error(`Scaffold ${flagScaffold} does not exist: ${err}`))
+              return
             }
             reject(err)
+            return
           }
           resolve()
         }

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -65,11 +65,9 @@ export default class New extends Command {
           if (err) {
             const fsExtraError = err as FsExtraError
             if (fsExtraError.code === 'ENOENT') {
-              reject(new Error(`Scaffold ${flagScaffold} does not exist: ${err}`))
-              return
+              return reject(new Error(`Scaffold ${flagScaffold} does not exist: ${err}`))
             }
-            reject(err)
-            return
+            return reject(err)
           }
           resolve()
         }

--- a/packages/zcli-apps/src/commands/apps/new.ts
+++ b/packages/zcli-apps/src/commands/apps/new.ts
@@ -47,7 +47,7 @@ export default class New extends Command {
         zip.extractAllToAsync(path.join(process.cwd()), overwrite, true, async (err) => {
           await cleanDirectory(this.zipScaffoldPath)
           if (err) {
-            reject(err)
+            return reject(err)
           }
           resolve()
         })


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Was going through the code with regards to the issue discussed [here](https://zendesk.slack.com/archives/C1230V1CG/p1713196954122779) and noticed that we should also `return` after the `reject()` to stop further execution, otherwise `resolve()` might still be called.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`2939523`](https://github.com/zendesk/zcli/pull/227/commits/2939523df34e9f6f961da44fa7bf7b7d068d52b2) Improve error handling



### [`7e1b980`](https://github.com/zendesk/zcli/pull/227/commits/7e1b980b1d40f3f97ad2dcb9dab095fcee141f61) Improve code by integrating the reject in the return



### [`35fda3f`](https://github.com/zendesk/zcli/pull/227/commits/35fda3f9bef4de6bb0b1e7e9949aa5825afbb3b2) Update the timeout settings



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
