### PR TITLE
doc: update doc for running zcli in headless Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        node-version: ["14.x"]
+        node-version: ["18.x"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: zendesk/checkout@v3
       - name: Use Node.js
-        uses: zendesk/setup-node@v3
+        uses: zendesk/setup-node@v4
         with:
           node-version: "${{ matrix.node-version }}"
           cache: "yarn"

--- a/README.md
+++ b/README.md
@@ -30,20 +30,30 @@ Depending on your distribution, you will need to run one of the following comman
 - Red Hat-based: `sudo yum install libsecret-devel`
 - Arch Linux: `sudo pacman -S libsecret`
 
-## Note for Windows users running Linux on WSL
 
-ZCLI's credential manager has a dependency on Linux's windowing manager (X11) which will cause some commands to fail to run on WSL, unless you run a setup of WSL with support for X11/GUI apps. These commands include: `zcli login`, `zcli logout` and `zcli profiles`.
+## Note for environments without Linux window manager (X11) support
+ZCLI's credential manager has a dependency on Linux's windowing manager (X11) which will cause some commands to fail to run on an environment without window manager support. These commands include: `zcli login`, `zcli logout` and `zcli profiles`.
 
-Features of ZCLI not dependent on ZCLI's credential manager will work in WSL2 without X11 support.
+### For headless Linux in a Docker container
+- Install  `gnome-keyring`, `dbus-x11` and the corresponding libsecret package listed above
+- Launch `dbus`
+```
+export $(dbus-launch)
+```
+- Unlock the Gnome keyring daemon with a dummy password
+```
+echo "123456" | gnome-keyring-daemon  -r --unlock --components=secrets
+```
 
-There are a number of workarounds:
+Refer to this sample [Dockerfile](/example/headless_ubuntu_zcli.Dockerfile) to see how you can run ZCLI on a headless installation of Ubuntu.
+### For Windows users running Linux on WSL
 
-* Manually starting a DBus session and unlocking the Gnome keyring with a password supplied via STDIN
+WSL2 now [supports running Linux GUI application](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps). For users unable to upgrade to WSL2, there are a number of workarounds available:
+
+* Manually starting a DBus session and unlocking the Gnome keyring with a password supplied via STDIN(similar to headless docker above)
 * Using X11 forwarding to be able to enable the Gnome keyring prompt to display
 
-**Windows 11 users**
 
-A better approach might be to await the upcoming support for GUI apps in WSL2 that Microsoft is [working on](https://youtu.be/f8_nvJzuaSU) and that is currently in [Preview](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
 
 # Commands
 
@@ -83,7 +93,7 @@ Thanks for your interest in ZCLI! Community involvement helps improve the experi
 
 Got issues with what you find here? You can [create an issue on Github](https://github.com/zendesk/zcli/issues/new), report the issue in the [Zendesk Developers Slack group](https://docs.google.com/forms/d/e/1FAIpQLScm_rDLWwzWnq6PpYWFOR_PwMaSBcaFft-1pYornQtBGAaiJA/viewform), or for other problems, [contact Zendesk Customer Support](https://support.zendesk.com/hc/en-us/articles/360026614173).
 
-If you'd like to take a crack at making some changes, please refer to [our contributing guide](.github/CONTRIBUTING.md). 
+If you'd like to take a crack at making some changes, please refer to [our contributing guide](.github/CONTRIBUTING.md).
 
 # ZAF App Scaffolding
 

--- a/example/headless_ubuntu_zcli.Dockerfile
+++ b/example/headless_ubuntu_zcli.Dockerfile
@@ -1,0 +1,48 @@
+# Use Ubuntu 22.04 LTS as base image
+FROM ubuntu:22.04
+
+# Install dependencies required for adding repositories
+RUN apt-get update && apt-get install -y curl gnupg2 ca-certificates lsb-release
+# Install required dependencies
+RUN apt-get update && apt-get install -y npm dbus-x11 libsecret-1-dev gnome-keyring
+
+# Make sure ca-certificates is installed
+RUN apt-get install -y ca-certificates
+
+# Install nvm, Node.js
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 18
+
+# Use bash shell for the install script
+SHELL ["/bin/bash", "-c"]
+
+# Install nvm (Note: the version might need updating)
+RUN mkdir -p $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+
+# Install Node.js 18 and set it as the default
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# Add nvm.sh to .bashrc for future login shells
+RUN echo 'export NVM_DIR="$NVM_DIR"' >> /etc/bash.bashrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/bash.bashrc
+
+# Add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN npm install @zendesk/zcli -g
+
+# For headless Linux:
+RUN echo 'export $(dbus-launch)' >> /etc/bash.bashrc
+# Init kerying storage by creating a default file
+RUN echo 'echo "123456" | gnome-keyring-daemon  -r --unlock --components=secrets' >> /etc/bash.bashrc
+
+
+# # Set the work directory
+WORKDIR /app
+
+# Command to run when starting the container
+CMD [ "bash" ]


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
Update doc to explain how to use zcli in headless Linux: to use gonme-keyring, a keyring has to be created first before entries can be saved to it.
<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`afd4627`](https://github.com/zendesk/zcli/pull/229/commits/afd46273079ac4aa524f88dbdb5f306d402e1fcf) doc: update doc for running zcli in headless Linux



### [`84cedfe`](https://github.com/zendesk/zcli/pull/229/commits/84cedfee1a1b9621679c4842a9430509dc1ed949) fix: node 14 doesn’t have any arm64 builds, upgrade to 18



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->
preview: 
![image](https://github.com/zendesk/zcli/assets/82128706/d16abf90-e34b-49ac-844e-bff5561b7141)



<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
