### PR TITLE
fix: `themes:preview` should respect the env variables

### DIFF
--- a/packages/zcli-themes/src/commands/themes/preview.ts
+++ b/packages/zcli-themes/src/commands/themes/preview.ts
@@ -9,7 +9,6 @@ import * as morgan from 'morgan'
 import * as chalk from 'chalk'
 import * as cors from 'cors'
 import * as chokidar from 'chokidar'
-import { Auth, getBaseUrl } from '@zendesk/zcli-core'
 import preview from '../../lib/preview'
 import getManifest from '../../lib/getManifest'
 import getVariables from '../../lib/getVariables'
@@ -56,8 +55,7 @@ export default class Preview extends Command {
       }
     }
 
-    await preview(themePath, flags)
-
+    const baseUrl = await preview(themePath, flags)
     const app = express()
     const server = httpsServerOptions === null ? http.createServer(app) : https.createServer(httpsServerOptions, app)
     const wss = new WebSocket.Server({ server, path: '/livereload' })
@@ -87,10 +85,6 @@ export default class Preview extends Command {
     })
 
     server.listen(port, host, async () => {
-      // preview requires authentication so we're sure
-      // to have a logged in profile at this point
-      const { subdomain, domain } = await new Auth().getLoggedInProfile()
-      const baseUrl = getBaseUrl(subdomain, domain)
       this.log(chalk.bold.green('Ready', chalk.blueBright(`${baseUrl}/hc/admin/local_preview/start`, '🚀')))
       this.log(`You can exit preview mode in the UI or by visiting ${baseUrl}/hc/admin/local_preview/stop`)
       tailLogs && this.log(chalk.bold('Tailing logs'))

--- a/packages/zcli-themes/src/lib/preview.test.ts
+++ b/packages/zcli-themes/src/lib/preview.test.ts
@@ -34,7 +34,7 @@ describe('preview', () => {
     sinon.restore()
   })
 
-  it('calls the local_preview endpoint with the correct payload', async () => {
+  it('calls the local_preview endpoint with the correct payload and returns the used baseURL', async () => {
     const getManifestStub = sinon.stub(getManifest, 'default')
     const getTemplatesStub = sinon.stub(getTemplates, 'default')
     const getVariablesStub = sinon.stub(getVariables, 'default')
@@ -63,10 +63,11 @@ describe('preview', () => {
 
     requestStub.returns(Promise.resolve({
       status: 200,
-      statusText: 'OK'
+      statusText: 'OK',
+      config: { baseURL: 'https://z3ntest.zendesk.com' }
     }) as axios.AxiosPromise)
 
-    await preview('theme/path', flags)
+    const baseUrl = await preview('theme/path', flags)
 
     expect(requestStub.calledWith('/hc/api/internal/theming/local_preview', sinon.match({
       method: 'put',
@@ -92,6 +93,8 @@ describe('preview', () => {
         }
       }
     }))).to.equal(true)
+
+    expect(baseUrl).to.equal('https://z3ntest.zendesk.com')
   })
 
   it('throws a comprehensive error when validation fails', async () => {

--- a/packages/zcli-themes/src/lib/preview.ts
+++ b/packages/zcli-themes/src/lib/preview.ts
@@ -11,7 +11,7 @@ import validationErrorsToString from './validationErrorsToString'
 import { getLocalServerBaseUrl } from './getLocalServerBaseUrl'
 import type { AxiosError } from 'axios'
 
-export default async function preview (themePath: string, flags: Flags): Promise<void> {
+export default async function preview (themePath: string, flags: Flags): Promise<string | void> {
   const manifest = getManifest(themePath)
   const templates = getTemplates(themePath)
   const variables = getVariables(themePath, manifest.settings, flags)
@@ -32,7 +32,7 @@ export default async function preview (themePath: string, flags: Flags): Promise
 
   try {
     CliUx.ux.action.start('Uploading theme')
-    await request.requestAPI('/hc/api/internal/theming/local_preview', {
+    const { config: { baseURL } } = await request.requestAPI('/hc/api/internal/theming/local_preview', {
       method: 'put',
       headers: {
         'X-Zendesk-Request-Originator': 'zcli themes:preview'
@@ -56,6 +56,7 @@ export default async function preview (themePath: string, flags: Flags): Promise
       validateStatus: (status: number) => status === 200
     })
     CliUx.ux.action.stop('Ok')
+    return baseURL
   } catch (e) {
     CliUx.ux.action.stop(chalk.bold.red('!'))
     const { response, message } = e as AxiosError

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -14,6 +14,7 @@ describe('themes:preview', function () {
     let server
 
     const preview = test
+      .stdout()
       .env({
         ZENDESK_SUBDOMAIN: 'z3ntest',
         ZENDESK_EMAIL: 'admin@z3ntest.com',
@@ -32,6 +33,12 @@ describe('themes:preview', function () {
       server.close()
       nock.cleanAll()
     })
+
+    preview
+      .it('should provide links and instructions to start and exit preview', async (ctx) => {
+        expect(ctx.stdout).to.contain('Ready https://z3ntest.zendesk.com/hc/admin/local_preview/start 🚀')
+        expect(ctx.stdout).to.contain('You can exit preview mode in the UI or by visiting https://z3ntest.zendesk.com/hc/admin/local_preview/stop')
+      })
 
     preview
       .it('should serve assets on the defined host and port', async () => {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Up until now we were using the `env` variables to make the preview api request but we'd use the logged in profile to notify the user when the preview was ready. This resulted in a couple of bugs when:

- The logged in profile does not match the `env` variables
- The logged in profile is `undefined` and the task failed since we couldn't destruct the `subdomain` and `domain`

This PR makes sure we always use the `baseUrl` from `request.requestAPI` since that's where all the logic for [figuring out the proper auth configuration](https://github.com/zendesk/zcli/blob/master/packages/zcli-core/src/lib/request.ts#L12-L26) lives.


<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`e7e2552`](https://github.com/zendesk/zcli/pull/239/commits/e7e255282939fe18b087c6a94ae422ff5a6db7b5) fix: use the baseUrl from the request api call



### [`0118dd3`](https://github.com/zendesk/zcli/pull/239/commits/0118dd34512e7e3685c6572808b1bc7a51ce0a73) test: cover preview fix with a unit test



### [`d6f560a`](https://github.com/zendesk/zcli/pull/239/commits/d6f560a58a2169587896e7077210c82b82dbde78) test: cover preview fix with a functional test



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
