### PR TITLE
Revert "fix: `themes:preview` should respect the env variables"

### DIFF
--- a/packages/zcli-themes/src/commands/themes/preview.ts
+++ b/packages/zcli-themes/src/commands/themes/preview.ts
@@ -9,6 +9,7 @@ import * as morgan from 'morgan'
 import * as chalk from 'chalk'
 import * as cors from 'cors'
 import * as chokidar from 'chokidar'
+import { Auth, getBaseUrl } from '@zendesk/zcli-core'
 import preview from '../../lib/preview'
 import getManifest from '../../lib/getManifest'
 import getVariables from '../../lib/getVariables'
@@ -55,7 +56,8 @@ export default class Preview extends Command {
       }
     }
 
-    const baseUrl = await preview(themePath, flags)
+    await preview(themePath, flags)
+
     const app = express()
     const server = httpsServerOptions === null ? http.createServer(app) : https.createServer(httpsServerOptions, app)
     const wss = new WebSocket.Server({ server, path: '/livereload' })
@@ -85,6 +87,10 @@ export default class Preview extends Command {
     })
 
     server.listen(port, host, async () => {
+      // preview requires authentication so we're sure
+      // to have a logged in profile at this point
+      const { subdomain, domain } = await new Auth().getLoggedInProfile()
+      const baseUrl = getBaseUrl(subdomain, domain)
       this.log(chalk.bold.green('Ready', chalk.blueBright(`${baseUrl}/hc/admin/local_preview/start`, '🚀')))
       this.log(`You can exit preview mode in the UI or by visiting ${baseUrl}/hc/admin/local_preview/stop`)
       tailLogs && this.log(chalk.bold('Tailing logs'))

--- a/packages/zcli-themes/src/lib/preview.test.ts
+++ b/packages/zcli-themes/src/lib/preview.test.ts
@@ -34,7 +34,7 @@ describe('preview', () => {
     sinon.restore()
   })
 
-  it('calls the local_preview endpoint with the correct payload and returns the used baseURL', async () => {
+  it('calls the local_preview endpoint with the correct payload', async () => {
     const getManifestStub = sinon.stub(getManifest, 'default')
     const getTemplatesStub = sinon.stub(getTemplates, 'default')
     const getVariablesStub = sinon.stub(getVariables, 'default')
@@ -63,11 +63,10 @@ describe('preview', () => {
 
     requestStub.returns(Promise.resolve({
       status: 200,
-      statusText: 'OK',
-      config: { baseURL: 'https://z3ntest.zendesk.com' }
+      statusText: 'OK'
     }) as axios.AxiosPromise)
 
-    const baseUrl = await preview('theme/path', flags)
+    await preview('theme/path', flags)
 
     expect(requestStub.calledWith('/hc/api/internal/theming/local_preview', sinon.match({
       method: 'put',
@@ -93,8 +92,6 @@ describe('preview', () => {
         }
       }
     }))).to.equal(true)
-
-    expect(baseUrl).to.equal('https://z3ntest.zendesk.com')
   })
 
   it('throws a comprehensive error when validation fails', async () => {

--- a/packages/zcli-themes/src/lib/preview.ts
+++ b/packages/zcli-themes/src/lib/preview.ts
@@ -11,7 +11,7 @@ import validationErrorsToString from './validationErrorsToString'
 import { getLocalServerBaseUrl } from './getLocalServerBaseUrl'
 import type { AxiosError } from 'axios'
 
-export default async function preview (themePath: string, flags: Flags): Promise<string | void> {
+export default async function preview (themePath: string, flags: Flags): Promise<void> {
   const manifest = getManifest(themePath)
   const templates = getTemplates(themePath)
   const variables = getVariables(themePath, manifest.settings, flags)
@@ -32,7 +32,7 @@ export default async function preview (themePath: string, flags: Flags): Promise
 
   try {
     CliUx.ux.action.start('Uploading theme')
-    const { config: { baseURL } } = await request.requestAPI('/hc/api/internal/theming/local_preview', {
+    await request.requestAPI('/hc/api/internal/theming/local_preview', {
       method: 'put',
       headers: {
         'X-Zendesk-Request-Originator': 'zcli themes:preview'
@@ -56,7 +56,6 @@ export default async function preview (themePath: string, flags: Flags): Promise
       validateStatus: (status: number) => status === 200
     })
     CliUx.ux.action.stop('Ok')
-    return baseURL
   } catch (e) {
     CliUx.ux.action.stop(chalk.bold.red('!'))
     const { response, message } = e as AxiosError

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -14,7 +14,6 @@ describe('themes:preview', function () {
     let server
 
     const preview = test
-      .stdout()
       .env({
         ZENDESK_SUBDOMAIN: 'z3ntest',
         ZENDESK_EMAIL: 'admin@z3ntest.com',
@@ -33,12 +32,6 @@ describe('themes:preview', function () {
       server.close()
       nock.cleanAll()
     })
-
-    preview
-      .it('should provide links and instructions to start and exit preview', async (ctx) => {
-        expect(ctx.stdout).to.contain('Ready https://z3ntest.zendesk.com/hc/admin/local_preview/start 🚀')
-        expect(ctx.stdout).to.contain('You can exit preview mode in the UI or by visiting https://z3ntest.zendesk.com/hc/admin/local_preview/stop')
-      })
 
     preview
       .it('should serve assets on the defined host and port', async () => {


### PR DESCRIPTION
Reverts zendesk/zcli#239
