### PR TITLE
fix(themes): replace all instances of `darken` and `lighten` in style.css

### DIFF
--- a/packages/zcli-themes/src/lib/zass.test.ts
+++ b/packages/zcli-themes/src/lib/zass.test.ts
@@ -2,6 +2,8 @@ import type { Variable } from '../types'
 import * as sinon from 'sinon'
 import * as path from 'path'
 import { expect } from '@oclif/test'
+import * as errors from '@oclif/core/lib/errors'
+import * as chalk from 'chalk'
 import zass from './zass'
 
 // Assert on minified css to ignore whitespace differences
@@ -99,6 +101,17 @@ describe('zass', () => {
         div { background-color: #ff00bf }
       `))
     })
+
+    it('errors with a descriptive message without exiting when it cannot darken a variable', () => {
+      const errorStub = sinon.stub(errors, 'error')
+
+      zass('div { color: darken( $nonexistent_variable, 10% ); }', [], [])
+
+      expect(errorStub.calledWithExactly(
+        `Could not process ${chalk.red('darken( $nonexistent_variable, 10% )')} in style.css`,
+        sinon.match({ exit: false })
+      )).to.equal(true)
+    })
   })
 
   describe('lighten', () => {
@@ -152,6 +165,17 @@ describe('zass', () => {
       )).to.deep.equal(minify(`
         div { background-color: #8894ff }
       `))
+    })
+
+    it('errors with a descriptive message without exiting when it cannot lighten a variable', () => {
+      const errorStub = sinon.stub(errors, 'error')
+
+      zass('div { color: lighten( $nonexistent_variable, 10% ); }', [], [])
+
+      expect(errorStub.calledWithExactly(
+        `Could not process ${chalk.red('lighten( $nonexistent_variable, 10% )')} in style.css`,
+        sinon.match({ exit: false })
+      )).to.equal(true)
     })
   })
 })

--- a/packages/zcli-themes/src/lib/zass.test.ts
+++ b/packages/zcli-themes/src/lib/zass.test.ts
@@ -72,6 +72,24 @@ describe('zass', () => {
       `))
     })
 
+    it('replaces multiple instances of `darken` with different arguments', () => {
+      expect(minify(zass(`
+        div {
+          background-color: darken( #ff33cc, 10% );
+          background-color: darken( #ff5, 10% );
+          background-color: darken( rgb(255, 1, 2), 10% );
+          background-color: darken( hsla(180, 50%, 50%, 0.2), 20% );
+        }
+      `, [], []))).to.deep.equal(minify(`
+        div {
+          background-color: #ff00bf;
+          background-color: #ff2;
+          background-color: #cd0001;
+          background-color: rgba(38, 115, 115, .2);
+        }
+      `))
+    })
+
     it('darkens a color defined in variables', () => {
       expect(minify(zass(
         'div { background-color: darken( $cool_color, 10% ) }',
@@ -105,6 +123,24 @@ describe('zass', () => {
     it('replaces color with hsla format', () => {
       expect(minify(zass('div { background-color: lighten( hsla(180, 50%, 50%, 0.2), 20% ) }', [], []))).to.deep.equal(minify(`
         div { background-color: rgba(140, 217, 217, .2) }
+      `))
+    })
+
+    it('replaces multiple instances of `lighten` with different arguments', () => {
+      expect(minify(zass(`
+        div {
+          background-color: lighten( #5566ff, 10% );
+          background-color: lighten( #55d, 10% );
+          background-color: lighten( rgb(255, 1, 2), 10% );
+          background-color: lighten( hsla(180, 50%, 50%, 0.2), 20% );
+        }
+      `, [], []))).to.deep.equal(minify(`
+        div {
+          background-color: #8894ff;
+          background-color: #8080e6;
+          background-color: #ff3435;
+          background-color: rgba(140, 217, 217, .2);
+        }
       `))
     })
 

--- a/packages/zcli-themes/src/lib/zass.ts
+++ b/packages/zcli-themes/src/lib/zass.ts
@@ -40,7 +40,7 @@ export default function zass (source: string, variables: Variable[], assets: [pa
 
   const command = /(?<command>lighten|darken)/i
   const percentage = /(?<percentage>\d{1,3})%/
-  const functionsRegex = new RegExp(`${command.source}\\s*\\((?<color>.*),\\s*${percentage.source}\\s*\\)`)
+  const functionsRegex = new RegExp(`${command.source}\\s*\\((?<color>.*),\\s*${percentage.source}\\s*\\)`, 'g')
 
   // `darken` and `lighten` functions may use variables so make
   // sure to replace them last

--- a/packages/zcli-themes/src/lib/zass.ts
+++ b/packages/zcli-themes/src/lib/zass.ts
@@ -53,7 +53,7 @@ export default function zass (source: string, variables: Variable[], assets: [pa
       // `dart-sass` does not provide an api to individually compile `darken` and `lighten`
       // functions so we improvise one using `compileString` with a valid SCSS string.
       // If such an api ever becomes available, we could switch to using it along with
-      // the named gorups "command", "color" and "percentage"
+      // the named groups "command", "color" and "percentage"
       const compiled = sass.compileString(prefix + match + suffix, { style: 'compressed' }).css
       const value = compiled.substring(prefix.length, compiled.length - suffix.length)
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

I have just now noticed that we were only replacing the first instance of `lighten` or `darken` used in `style.css` when previewing themes 🤦🏼‍♂️.

I believe most developers are probably fully compiling their stylesheets with with SASS or something else and not relying on these functions at all and that's why we haven't had issue reports about it. However, this is a supported feature in Help Center so this PR fixes that bug.

I have also added some error handling for when `lighten` and `darken` are passed in undefined variables.


<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`b828b9c`](https://github.com/zendesk/zcli/pull/248/commits/b828b9cc2a28ff8107d6ca84e00dd4ebca85f78c) fix: replace all instances of lighten and darken functions



### [`0ddadb4`](https://github.com/zendesk/zcli/pull/248/commits/0ddadb41e17272bcb2385afa0e261a16234aa568) test: cover replacement of all lighten and darken functions



### [`a45f319`](https://github.com/zendesk/zcli/pull/248/commits/a45f31943fdaf1032951111516a78746380fafde) fix: handle compilation errors for lighten and darken functions



### [`77c5865`](https://github.com/zendesk/zcli/pull/248/commits/77c5865e3ce19f367ae28b8bedf2a8f386e3a615) test: cover errors when lighten and darken fails due to missing variables



### [`bc54872`](https://github.com/zendesk/zcli/pull/248/commits/bc54872f87c33b23b78b3aa13f4efca288252d01) doc: fix typo in comment

Co-authored-by: BrunoBFerreira <BrunoBFerreira@users.noreply.github.com>

<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
