### PR TITLE
[NO JIRA] fix: failing tests due to rebase and vite migration

### DIFF
--- a/packages/zcli-apps/tests/functional/new.test.ts
+++ b/packages/zcli-apps/tests/functional/new.test.ts
@@ -74,9 +74,9 @@ describe('apps new', () => {
       await cleanDirectory(dirPath)
     })
 
-    test.it('should create a directory with webpack configs', async () => {
-      const webpackPath = path.join(process.cwd(), dirName, 'webpack')
-      expect(fs.existsSync(webpackPath)).to.eq(true)
+    test.it('should create a vite config file', async () => {
+      const viteConfigPath = path.join(process.cwd(), dirName, 'vite.config.js')
+      expect(fs.existsSync(viteConfigPath)).to.eq(true)
     })
 
     test.it('updates manifest.json with user input values', async () => {

--- a/packages/zcli-core/src/lib/request.test.ts
+++ b/packages/zcli-core/src/lib/request.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@oclif/test'
 import { createRequestConfig, requestAPI } from './request'
-import { HttpStatusCode } from 'axios'
 import * as requestUtils from './requestUtils'
 import Auth from './auth'
 import { Profile } from '../types'
@@ -103,10 +102,10 @@ describe('requestAPI', () => {
     .nock('https://z3ntest.zendesk.com', api => {
       api
         .get('/api/v2/me')
-        .reply(HttpStatusCode.Ok)
+        .reply(200)
     })
     .it('should call an http endpoint', async () => {
       const response = await requestAPI('api/v2/me', { method: 'GET' })
-      expect(response.status).to.equal(HttpStatusCode.Ok)
+      expect(response.status).to.equal(200)
     })
 })


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
Fix two unit test issues:
 - [PR](https://github.com/zendesk/zcli/pull/238) dropping support for password based basic auth was merged but a test using axios@1.7.2 was not reverted. Test succeeded probably due to github action caching.
 - For app scaffolding, webpack is dropped in favour of vite: https://github.com/zendesk/app_scaffolds/pull/16
 
Relevant discussion here: https://zendesk.slack.com/archives/CSQD7LRRT/p1722598486950829


<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`eede77d`](https://github.com/zendesk/zcli/pull/249/commits/eede77d63514a69ff0725a40065ccf00e90da3ec) fix: failing unit test



### [`e5c81cf`](https://github.com/zendesk/zcli/pull/249/commits/e5c81cfb21612fcd5fadd2c3f4aee27d0df620ba) fix: webpack unit test to use vite



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
