### PR TITLE
fix(themes): increase default retries in jobPollStatus

### DIFF
--- a/packages/zcli-themes/src/lib/pollJobStatus.ts
+++ b/packages/zcli-themes/src/lib/pollJobStatus.ts
@@ -5,7 +5,7 @@ import { request } from '@zendesk/zcli-core'
 import * as chalk from 'chalk'
 import validationErrorsToString from './validationErrorsToString'
 
-export default async function pollJobStatus (themePath: string, jobId: string, interval = 1000, retries = 10): Promise<void> {
+export default async function pollJobStatus (themePath: string, jobId: string, interval = 1000, retries = 20): Promise<void> {
   CliUx.ux.action.start('Polling job status')
 
   while (retries) {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

One of our customers is using ZCLI to automate their CI/CD and import themes. However, sometimes they are getting an error from the import command due to time out, but the theme is actually imported.

This happens because the `pollJobStatus` is using all the retries to fetch the job status but the job ends up finishing after all the checks are used. 

To prevent this from happening and in an attempt to make this command more stable, we are increasing the default value for retries, so that we continue polling for the status, giving more time for the job to update its status. 

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`b381fe9`](https://github.com/zendesk/zcli/pull/276/commits/b381fe9fb1100e596668232f85408ab426f807a1) fix(themes): increase default retries in jobPollStatus



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
