### PR TITLE
Fix/278 themes errors is not iterable

### DIFF
--- a/packages/zcli-themes/src/lib/handleThemeApiError.ts
+++ b/packages/zcli-themes/src/lib/handleThemeApiError.ts
@@ -5,7 +5,7 @@ import { error } from '@oclif/core/lib/errors'
 export default function handleThemeApiError (e: AxiosError): never {
   const { response, message } = e
 
-  if (response) {
+  if (response?.data) {
     const { errors } = (response as AxiosResponse).data
     for (const { code, title } of errors) {
       error(`${chalk.bold(code)} - ${title}`)

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -168,4 +168,28 @@ describe('themes:import', function () {
         }
       })
   })
+
+  describe('import unauthorized', () => {
+    test
+      .stderr()
+      .env(env)
+      .do(() => {
+        fetchStub.withArgs(sinon.match({
+          url: 'https://z3ntest.zendesk.com/api/v2/guide/theming/jobs/themes/imports',
+          method: 'POST'
+        })).resolves({
+            status: 401,
+            ok: false,
+            text: () => Promise.resolve('')
+        })
+      })
+      .it('should report request failed with status code', async (ctx) => {
+        try {
+          await ImportCommand.run([baseThemePath, '--brandId', '1111'])
+        } catch (error) {
+          expect(ctx.stderr).to.contain('!')
+          expect(error.message).to.contain('Request failed with status code 401')
+        }
+      })
+  })
 })

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -178,9 +178,9 @@ describe('themes:import', function () {
           url: 'https://z3ntest.zendesk.com/api/v2/guide/theming/jobs/themes/imports',
           method: 'POST'
         })).resolves({
-            status: 401,
-            ok: false,
-            text: () => Promise.resolve('')
+          status: 401,
+          ok: false,
+          text: () => Promise.resolve('')
         })
       })
       .it('should report request failed with status code', async (ctx) => {


### PR DESCRIPTION
Closes #278

<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Do NOT write here! This section will be filled in by GitHub Action
automatically. If you don't want this, either remove the markers or write
outside the fences.
<!-- === GH HISTORY FENCE === -->

## Detail

Before fix:
```
ZENDESK_SUBDOMAIN=foo ZENDESK_EMAIL=user@example.com ZENDESK_API_TOKEN=hunter2 yarn dev themes:import --brandId=123 .
yarn run v1.22.22
$ ts-node ./packages/zcli/bin/run themes:import --brandId=123 .
Creating theme import job... !
TypeError: errors is not iterable
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
After fix:
``` 
ZENDESK_SUBDOMAIN=foo ZENDESK_EMAIL=user@example.com ZENDESK_API_TOKEN=hunter2 yarn dev themes:import --brandId=123 .
yarn run v1.22.22
$ ts-node ./packages/zcli/bin/run themes:import --brandId=123 .
Creating theme import job... !
›   Error: Request failed with status code 401
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Closes #278

## Checklist

- [x] :guardsman: includes new unit and functional tests
