### PR TITLE
Add stale config to automatically close stale PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,72 @@
+# Configuration for zendesk-stale - https://github.com/zendesk/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: [long-term]
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Enable to delete branches after inactivity period. Set to `false` to disable
+enableBranches: true
+
+# Number of days of inactivity before deleting the branch
+daysUntilDeleteBranches: 90
+
+# Regex Examples: https://www.w3schools.com/jsref/jsref_obj_regexp.asp
+# Branch name matches the regular expression will not be considered for deletion. Set to `false` to disable
+exemptBranches: false
+
+# Branch name matches the regular expression will only be considered for deletion. Set to `false` to disable
+onlyBranches: false
+
+# Branches created by given `Github Usernames` will only be considered for deletion. Set to `[]` to disable
+onlyBranchesCreatedBy: []
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed
+
+# Optionally, specify configuration settings that are specific to just 'branches':
+# branches:
+# enableBranches: true
+# daysUntilDeleteBranches: 30


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
Adds a configuration for the zendesk stale GH app to automatically close out stale issues, PRs and branches.



<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`ec593c8`](https://github.com/zendesk/zcli/pull/291/commits/ec593c891c32205db2f0db3b9a92f75d7a8e736e) add stale config



<!-- === GH HISTORY FENCE === -->

## Detail


See here for more details: https://github.com/zendesk/stale

The settings I've put are, if open for more than 90 days will be closed.
PRs and issues will receive a comment at that point and will be closed after 14 days if no activity has occurred.
I've also created a label `long-term` which can be applied to anything you wish to be saved.

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
