### PR TITLE
feat: support env vars for settings

### DIFF
--- a/packages/zcli-apps/src/utils/createApp.ts
+++ b/packages/zcli-apps/src/utils/createApp.ts
@@ -38,8 +38,16 @@ export const uploadAppPkg = async (pkgPath: string): Promise<any> => {
 export const promptAndGetSettings = async (params: ManifestParameter[], appName = 'app', valuesRequired = true) => {
   const settings: Dictionary<string> = {}
   for (const param of params) {
-    const value = await CliUx.ux.prompt(`Enter ${appName} setting.${param.name} value`, { type: param.secure ? 'hide' : 'normal', required: valuesRequired })
-    if (value) settings[param.name] = value
+    let value
+    const valueFromEnv = process.env[param.name]
+    if (valueFromEnv) {
+      value = valueFromEnv
+    } else {
+      value = await CliUx.ux.prompt(`Enter ${appName} setting.${param.name} value`, { type: param.secure ? 'hide' : 'normal', required: valuesRequired })
+    }
+    if (value) {
+      settings[param.name] = value
+    }
   }
   return settings
 }


### PR DESCRIPTION
## Description

This PR instroduces support for setting environment variables for settings configured in manifest instead off relying on interactive shells. The reason is to support a use-case as follows:

I'm using Vue + Vite to develop a Zendesk App. I have configured some scripts in my `package.json` as follows:

```json
{
  "scripts": {
    "build": "dotenv -- npm-run-all lint typecheck build:vite build:zd",
    "build:vite": "vite build",
    "build:zd": "zcli apps:package ./dist/",
    "dev": "dotenv -- npm-run-all --parallel \"build:vite -- --emptyOutDir false --watch\" dev:zd",
    "dev:vite": "vite dev",
    "dev:zd": "zcli apps:server ./dist/",
    "lint": "biome check",
    "typecheck": "vue-tsc --noEmit"
  }
}
```
So far, I was just running `npm run dev` and it was all working fine for me from a single shell. However, then I introduced a secure setting which now prompts me to enter some text when I run `zcli apps:server`. Since I'm running this with `npm-run-all`, I never get a chance to enter my text and the script fails.

Instead, if the value can be set from environment variables, that would solve the issue.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Do NOT write here! This section will be filled in by GitHub Action
automatically. If you don't want this, either remove the markers or write
outside the fences.
<!-- === GH HISTORY FENCE === -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
