### PR TITLE
fix(VEG-3633): Refactor the connector commands

### DIFF
--- a/packages/zcli-connectors/src/commands/connectors/bundle.ts
+++ b/packages/zcli-connectors/src/commands/connectors/bundle.ts
@@ -8,22 +8,12 @@ import * as ora from 'ora'
 
 export default class Bundle extends Command {
   static examples = [
-    '<%= config.bin %> <%= command.id %> ./example-connector',
-    '<%= config.bin %> <%= command.id %> ./example-connector --output ./bundled',
-    '<%= config.bin %> <%= command.id %> --input ./src --output ./bundle'
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> ./example-connector'
   ]
 
   static flags = {
     help: Flags.help({ char: 'h' }),
-    input: Flags.string({
-      char: 'i',
-      description: 'input directory containing connector source files',
-      default: '.'
-    }),
-    output: Flags.string({
-      char: 'o',
-      description: 'output directory for bundled files'
-    }),
     verbose: Flags.boolean({
       char: 'v',
       description: 'verbose output',
@@ -39,21 +29,21 @@ export default class Bundle extends Command {
   static args = [
     {
       name: 'path',
-      description: 'path to connector directory (will use src/ folder inside)'
+      description: 'relative path to connector root directory (optional, defaults to current directory)'
     }
   ]
 
   async run (): Promise<void> {
     const { args, flags } = await this.parse(Bundle)
 
-    let inputPath: string
-    if (args.path) {
-      inputPath = resolve(join(args.path, 'src'))
-    } else {
-      inputPath = resolve(flags.input)
-    }
+    // Resolve connector root once upfront for consistent path handling
+    const connectorRoot = resolve(args.path || '.')
+    const inputPath = connectorRoot
+    const outputPath = join(connectorRoot, 'dist')
 
-    const outputPath = flags.output ? resolve(flags.output) : resolve('dist')
+    // Validate connector root directory exists and contains expected structure
+    this.validateConnectorRoot(connectorRoot)
+
     if (!existsSync(outputPath)) {
       mkdirSync(outputPath, { recursive: true })
       if (flags.verbose) {
@@ -72,7 +62,6 @@ export default class Bundle extends Command {
 
     try {
       this.checkTypeScript(inputPath, spinner)
-      spinner.succeed(chalk.green('TypeScript compilation check passed'))
 
       spinner = ora(
         `Bundling connector from ${inputPath} to ${outputPath}...`
@@ -114,6 +103,7 @@ export default class Bundle extends Command {
 
       spinner.text = chalk.cyan('Running TypeScript type check...')
       execFileSync('tsc', ['--noEmit', '--project', projectPath], { stdio: 'inherit' })
+      spinner.succeed(chalk.green('TypeScript compilation check passed'))
     } catch (error) {
       spinner.fail(chalk.red('TypeScript type check failed'))
       throw new Error('TypeScript compilation check failed. Please fix the errors above.')
@@ -156,7 +146,7 @@ export default class Bundle extends Command {
       spinner.fail(chalk.red('Bundle failed with errors!'))
 
       const errors = stats.toJson().errors || []
-      this.log(chalk.cyan(`Found ${errors.length} error(s)`))
+      this.log(chalk.red(`Found ${errors.length} error(s)`))
       errors.forEach((error: any) => {
         this.log(chalk.red(`Error: ${error.message}`))
       })
@@ -185,6 +175,16 @@ export default class Bundle extends Command {
       })
     } else if (verbose) {
       this.log(chalk.cyan('No warnings found'))
+    }
+  }
+
+  private validateConnectorRoot (connectorRoot: string): void {
+    // Check if the connector root directory exists
+    if (!existsSync(connectorRoot)) {
+      this.error(
+        chalk.red(`Connector root directory does not exist: ${connectorRoot}`),
+        { exit: 1 }
+      )
     }
   }
 }

--- a/packages/zcli-connectors/src/commands/connectors/create.ts
+++ b/packages/zcli-connectors/src/commands/connectors/create.ts
@@ -11,12 +11,7 @@ export default class Create extends Command {
   ]
 
   static flags = {
-    help: Flags.help({ char: 'h' }),
-    author: Flags.string({
-      char: 'a',
-      description: 'Author of the connector',
-      required: true
-    })
+    help: Flags.help({ char: 'h' })
   }
 
   static args = [
@@ -28,14 +23,14 @@ export default class Create extends Command {
   ]
 
   async run (): Promise<void> {
-    const { args, flags } = await this.parse(Create)
+    const { args } = await this.parse(Create)
     const { connector } = args
     this.log(`creating ${connector} connector ...`)
 
     const cwd = process.cwd()
     const __connectorDir = resolve(cwd, `./${connector}`)
     if (existsSync(__connectorDir)) {
-      this.error(chalk.cyan(`Error: Directory ${connector} already exists in ${cwd}`))
+      this.error(chalk.red(`Error: Directory ${connector} already exists in ${cwd}`))
     }
 
     const __dirname = dirname(__filename)
@@ -51,8 +46,7 @@ export default class Create extends Command {
     replaceInFile(indexTsPath, {
       "name: 'starter'": `name: '${connector}'`,
       "title: 'Starter Connector'": `title: '${toTitleCase(connector)}'`,
-      "description: 'Starter Connector'": `description: '${toTitleCase(connector)} connector'`,
-      "author: 'starter-author'": `author: '${flags.author}'`
+      "description: 'Starter Connector'": `description: '${toTitleCase(connector)} connector'`
     })
 
     this.log(`✅ Connector '${connector}' created successfully!`)

--- a/packages/zcli-connectors/src/lib/validations/assetsValidation.test.ts
+++ b/packages/zcli-connectors/src/lib/validations/assetsValidation.test.ts
@@ -65,20 +65,6 @@ describe('validateAssets', () => {
       expect(logSpy.getCall(2).args[0]).to.include('Logo file validated')
       expect(logSpy.getCall(3).args[0]).to.include('Assets and resources validation passed')
     })
-
-    it('should not validate assets if assets directory does not exist', async () => {
-      existsSyncStub.returns(false)
-
-      const context: ValidationContext = {
-        inputPath: '/path/to/dist',
-        options: { verbose: false },
-        log: logSpy
-      }
-
-      await validateAssets(context)
-
-      expect(logSpy.called).to.equal(false)
-    })
   })
 
   describe('validation failures', () => {
@@ -217,6 +203,24 @@ describe('validateAssets', () => {
       } catch (error) {
         expect((error as Error).message).to.include('too large')
         expect((error as Error).message).to.include('5KB')
+      }
+    })
+
+    it('should throw error when assets directory does not exist', async () => {
+      existsSyncStub.returns(false)
+
+      const context: ValidationContext = {
+        inputPath: '/path/to/dist',
+        options: { verbose: false },
+        log: logSpy
+      }
+
+      try {
+        await validateAssets(context)
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        expect((error as Error).message).to.include('Assets validation failed')
+        expect((error as Error).message).to.include('Assets directory is required but does not exist')
       }
     })
   })

--- a/packages/zcli-connectors/src/lib/validations/assetsValidation.ts
+++ b/packages/zcli-connectors/src/lib/validations/assetsValidation.ts
@@ -19,9 +19,11 @@ export function validateAssets (context: ValidationContext): void {
 
   try {
     const assetsPath = join(inputPath, 'assets')
-    if (existsSync(assetsPath)) {
-      validateAssetsDirectory(assetsPath, options, log)
+    if (!existsSync(assetsPath)) {
+      throw new Error(`Assets directory is required but does not exist: ${assetsPath}`)
     }
+
+    validateAssetsDirectory(assetsPath, options, log)
 
     if (options.verbose) {
       log(chalk.cyan('  ✓ Assets and resources validation passed'))

--- a/packages/zcli-connectors/src/lib/validations/manifestValidation.ts
+++ b/packages/zcli-connectors/src/lib/validations/manifestValidation.ts
@@ -44,7 +44,7 @@ export function validateManifest (context: ValidationContext): void {
       )
     }
     const errorMessage = error instanceof Error ? error.message : String(error)
-    throw new Error(`Manifest validation failed: ${errorMessage}. Update the manifest definition and re-run the bundle command.`)
+    throw new Error(`Manifest validation failed: ${errorMessage}. Update the manifest definition in your connector's src/index.ts file and re-run \`zcli connectors:bundle ./{connector-name}\``)
   }
 }
 

--- a/packages/zcli-connectors/tests/functional/bundle.test.ts
+++ b/packages/zcli-connectors/tests/functional/bundle.test.ts
@@ -19,7 +19,11 @@ describe('bundle', () => {
   beforeEach(() => {
     fsStubs = {
       existsSync: sinon.stub(fs, 'existsSync').callsFake((path: fs.PathLike) => {
-        return !String(path).includes('tsconfig.json')
+        const pathStr = String(path)
+        // Return false for tsconfig.json (to skip type check) and for non-existent connector dirs in specific tests
+        if (pathStr.includes('tsconfig.json')) return false
+        if (pathStr.includes('/nonexistent') || pathStr.includes('\\nonexistent')) return false
+        return true // connector root and dist directories exist by default
       }),
       mkdirSync: sinon.stub(fs, 'mkdirSync')
     }
@@ -78,7 +82,13 @@ describe('bundle', () => {
   })
 
   it('should create output directory if it does not exist', async () => {
-    fsStubs.existsSync.returns(false)
+    // Make connector root exist but dist directory not exist
+    fsStubs.existsSync.callsFake((path: fs.PathLike) => {
+      const pathStr = String(path)
+      if (pathStr.includes('tsconfig.json')) return false
+      if (pathStr.endsWith('/dist') || pathStr.endsWith('\\dist')) return false
+      return true // connector root exists
+    })
 
     await bundleCommand.run()
 
@@ -123,7 +133,7 @@ describe('bundle', () => {
   it('should pass correct config to ViteConfigBuilder', async () => {
     (bundleCommand as any).parse = sinon.stub().resolves({
       args: { path: './test-dir' },
-      flags: { output: './output', watch: false, verbose: false }
+      flags: { watch: false, verbose: false }
     })
 
     await bundleCommand.run()
@@ -138,7 +148,7 @@ describe('bundle', () => {
   it('should enable watch mode', async () => {
     (bundleCommand as any).parse = sinon.stub().resolves({
       args: { path: '.' },
-      flags: { output: undefined, watch: true, verbose: false }
+      flags: { watch: true, verbose: false }
     })
 
     await bundleCommand.run()
@@ -153,7 +163,7 @@ describe('bundle', () => {
   it('should fail bundle if TypeScript compilation fails', async () => {
     (bundleCommand as any).parse = sinon.stub().resolves({
       args: { path: './test-dir' },
-      flags: { output: './output', watch: false, verbose: true }
+      flags: { watch: false, verbose: true }
     })
 
     fsStubs.existsSync.returns(true)
@@ -169,6 +179,31 @@ describe('bundle', () => {
       expect(logStub).to.have.been.calledWith(sinon.match(/compilation check failed/i))
     } finally {
       execSyncStub.restore()
+    }
+  })
+
+  it('should fail if connector directory does not exist', async () => {
+    (bundleCommand as any).parse = sinon.stub().resolves({
+      args: { path: './nonexistent-dir' },
+      flags: { watch: false, verbose: false }
+    })
+
+    const errorStub = sinon.stub(bundleCommand, 'error').callsFake((message: any, options: any) => {
+      const err = new Error(String(message))
+      ;(err as any).options = options
+      throw err
+    })
+    try {
+      await bundleCommand.run()
+      expect.fail('Expected bundleCommand.run() to throw when connector directory does not exist')
+    } catch (error: any) {
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Connector root directory does not exist/),
+        sinon.match({ exit: 1 })
+      )
+      expect(error.message).to.match(/Connector root directory does not exist/)
+    } finally {
+      errorStub.restore()
     }
   })
 })


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

  Summary

  - bundle command: Simplified the CLI interface by removing --input/--output flags in favor of a positional path argument. The command now resolves paths relative to the connector root directory (defaulting to the current directory), and output
   defaults to <connector-root>/dist. Also moved the TypeScript success spinner message to after the type check completes, and improved error output color (cyan → red).
  - create command: Removed the --author flag; author is no longer scaffolded into the connector template during creation. Improved error message color consistency (cyan → red).
  - assetsValidation: Changed behavior so that a missing assets directory is now a hard validation error rather than a silent no-op. Updated the corresponding test to assert the error is thrown.
  - manifestValidation: Improved the error message to reference the specific file (index.ts) and the correct bundle command invocation.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c4c0157`](https://github.com/zendesk/zcli/pull/319/commits/c4c0157ec332c6965b24e42adbc6f103c97adcb7) Refactor the connector commands



<!-- === GH HISTORY FENCE === -->

## Detail
Ref: https://zendesk.atlassian.net/browse/VEG-3633
<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [x] :guardsman: includes new unit and functional tests
