### PR TITLE
feat(VEG-3618): Adds the status command to display the provisioning status of a connector

### DIFF
--- a/packages/zcli-connectors/src/commands/connectors/publish/index.ts
+++ b/packages/zcli-connectors/src/commands/connectors/publish/index.ts
@@ -3,9 +3,9 @@ import { existsSync } from 'fs'
 import { resolve, join } from 'path'
 import * as chalk from 'chalk'
 import * as ora from 'ora'
-import { runValidationChecks } from '../../lib/validations'
-import { createConnector, uploadConnectorPackage } from '../../lib/publish/publish'
-import { pollProvisioningStatus } from '../../lib/publish/poller'
+import { runValidationChecks } from '../../../lib/validations'
+import { createConnector, uploadConnectorPackage } from '../../../lib/publish/publish'
+import { pollProvisioningStatus } from '../../../lib/publish/poller'
 
 export default class Publish extends Command {
   static description = 'publish a connector'
@@ -98,12 +98,12 @@ export default class Publish extends Command {
   ): Promise<void> {
     let spinner = ora('Publishing connector...').start()
     try {
-      const { uploadUrl, connectorName, jobId } = await createConnector(path)
+      const { uploadUrl, connectorName, provisioningId } = await createConnector(path)
       await uploadConnectorPackage(path, uploadUrl, connectorName)
       spinner.succeed(chalk.green('Upload complete'))
 
       spinner = ora('Waiting for connector provisioning...').start()
-      const { status: finalStatus, reason } = await pollProvisioningStatus(connectorName, jobId)
+      const { status: finalStatus, reason } = await pollProvisioningStatus(connectorName, provisioningId)
 
       if (finalStatus === 'SUCCESS') {
         spinner.succeed(chalk.green('Connector provisioned successfully!'))

--- a/packages/zcli-connectors/src/commands/connectors/publish/status.ts
+++ b/packages/zcli-connectors/src/commands/connectors/publish/status.ts
@@ -1,0 +1,115 @@
+import { Command, Flags } from '@oclif/core'
+import { existsSync, readFileSync } from 'fs'
+import { join, resolve } from 'path'
+import * as chalk from 'chalk'
+import * as ora from 'ora'
+import { getProvisioningStatus } from '../../../lib/publish/status'
+
+export default class PublishStatus extends Command {
+  static description = 'check the provisioning status of a published connector'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> ./example-connector'
+  ]
+
+  static flags = {
+    help: Flags.help({ char: 'h' })
+  }
+
+  static args = [
+    {
+      name: 'path',
+      description: 'path to connector directory (defaults to current directory)',
+      required: false,
+      default: '.'
+    }
+  ]
+
+  async run (): Promise<void> {
+    const { args } = await this.parse(PublishStatus)
+
+    const connectorPath = resolve(args.path)
+    const distPath = join(connectorPath, 'dist')
+    const manifestPath = join(distPath, 'manifest.json')
+
+    if (!existsSync(distPath)) {
+      this.error(
+        chalk.red(`Error: dist directory not found in ${connectorPath}. Please run 'zcli connectors:bundle' first to generate the dist folder.`),
+        { exit: 1 }
+      )
+    }
+
+    if (!existsSync(manifestPath)) {
+      this.error(
+        chalk.red(`Error: manifest.json not found in ${distPath}. Please run 'zcli connectors:bundle' first to generate the manifest.`),
+        { exit: 1 }
+      )
+    }
+
+    let connectorName: string
+    try {
+      const manifestContent = readFileSync(manifestPath, 'utf-8')
+      const manifest = JSON.parse(manifestContent)
+
+      connectorName = manifest.name
+    } catch (error) {
+      this.error(
+        chalk.red(`Error reading manifest.json: ${error instanceof Error ? error.message : String(error)}`),
+        { exit: 1 }
+      )
+    }
+
+    if (!connectorName) {
+      this.error(
+        chalk.red('Error: Connector name not found in manifest.json'),
+        { exit: 1 }
+      )
+    }
+
+    const spinner = ora(`Fetching provisioning status for '${connectorName}'...`).start()
+
+    try {
+      const result = await getProvisioningStatus(connectorName)
+      spinner.stop()
+
+      this.log('')
+      this.log(chalk.bold(`Connector: ${result.connectorName}  (v${result.version})`))
+      this.log('')
+
+      switch (result.status) {
+      case 'PENDING_UPLOAD':
+        this.log(chalk.yellow('Status: Waiting for upload'))
+        this.log(chalk.cyan('  The connector code has not been uploaded yet. Run `zcli connectors:publish` to upload it.'))
+        break
+
+      case 'PENDING_VALIDATION':
+        this.log(chalk.yellow('Status: Validating'))
+        this.log(chalk.cyan('The connector has been received and is currently being validated. This usually takes a few minutes.'))
+        break
+
+      case 'SUCCESS':
+        this.log(chalk.green('Status: Provisioned'))
+        this.log(chalk.cyan('The connector has been successfully provisioned.'))
+        break
+
+      case 'FAILED':
+        this.log(chalk.red('Status: Failed'))
+        this.log(chalk.red(`Provisioning failed: ${result.reason ?? 'No reason provided.'}`))
+        break
+
+      default:
+        this.log(chalk.yellow(`Status: ${result.status}`))
+        if (result.reason) {
+          this.log(chalk.cyan(`   ${result.reason}`))
+        }
+      }
+
+      this.log('')
+    } catch (error) {
+      spinner.fail(chalk.red(`Failed to fetch status for '${connectorName}'`))
+      const errorMessage = (error instanceof Error) ? error.message : String(error)
+      this.error(errorMessage, { exit: 1 })
+    }
+  }
+}

--- a/packages/zcli-connectors/src/lib/publish/publish.test.ts
+++ b/packages/zcli-connectors/src/lib/publish/publish.test.ts
@@ -58,7 +58,7 @@ describe('publish', () => {
         status: 201,
         data: {
           upload_url: 'https://example.com/upload/123',
-          job_id: 'job-123'
+          id: '01KKWDA6BV6SGNQRFSMW5HEYSY'
         }
       } as any)
 
@@ -66,7 +66,7 @@ describe('publish', () => {
 
       expect(result.uploadUrl).to.equal('https://example.com/upload/123')
       expect(result.connectorName).to.equal('my-connector')
-      expect(result.jobId).to.equal('job-123')
+      expect(result.provisioningId).to.equal('01KKWDA6BV6SGNQRFSMW5HEYSY')
       expect(readFileSyncStub.calledOnce).to.equal(true)
       expect(requestAPIStub.calledOnce).to.equal(true)
     })
@@ -82,7 +82,7 @@ describe('publish', () => {
         status: 201,
         data: {
           upload_url: 'https://example.com/upload/456',
-          job_id: 'job-456'
+          id: 'job-456'
         }
       } as any)
 
@@ -90,7 +90,7 @@ describe('publish', () => {
 
       expect(result.uploadUrl).to.equal('https://example.com/upload/456')
       expect(result.connectorName).to.equal('test-connector')
-      expect(result.jobId).to.equal('job-456')
+      expect(result.provisioningId).to.equal('job-456')
 
       const callArgs = requestAPIStub.getCall(0)
       expect(callArgs.args[0]).to.equal('/flowstate/connectors/private/create')

--- a/packages/zcli-connectors/src/lib/publish/publish.ts
+++ b/packages/zcli-connectors/src/lib/publish/publish.ts
@@ -57,7 +57,7 @@ export async function cleanupPackageArchive (archivePath: string): Promise<void>
   })
 }
 
-export async function createConnector (path: string): Promise<{ uploadUrl: string; connectorName: string; jobId: string }> {
+export async function createConnector (path: string): Promise<{ uploadUrl: string; connectorName: string; provisioningId: string }> {
   const manifestPath = join(path, 'manifest.json')
   const manifestContent = fs.readFileSync(manifestPath, 'utf-8')
   const manifest = JSON.parse(manifestContent)
@@ -84,7 +84,7 @@ export async function createConnector (path: string): Promise<{ uploadUrl: strin
   return {
     uploadUrl: response.data.upload_url,
     connectorName,
-    jobId: response.data.job_id
+    provisioningId: response.data.id
   }
 }
 

--- a/packages/zcli-connectors/src/lib/publish/status.test.ts
+++ b/packages/zcli-connectors/src/lib/publish/status.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { request } from '@zendesk/zcli-core'
+import { getProvisioningStatus } from './status'
+
+describe('getProvisioningStatus', () => {
+  let requestAPIStub: sinon.SinonStub
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should return the provisioning status for a connector', async () => {
+    requestAPIStub = sinon.stub(request, 'requestAPI').resolves({
+      status: 200,
+      data: {
+        id: '01KKWDA6BV6SGNQRFSMW5HEYSY',
+        connector_name: 'my-connector',
+        version: '1.0.0',
+        status: 'SUCCESS',
+        reason: null
+      }
+    } as any)
+
+    const result = await getProvisioningStatus('my-connector')
+
+    expect(result.id).to.equal('01KKWDA6BV6SGNQRFSMW5HEYSY')
+    expect(result.connectorName).to.equal('my-connector')
+    expect(result.version).to.equal('1.0.0')
+    expect(result.status).to.equal('SUCCESS')
+    expect(result.reason).to.equal(undefined)
+  })
+
+  it('should call the correct endpoint with the connector name', async () => {
+    requestAPIStub = sinon.stub(request, 'requestAPI').resolves({
+      status: 200,
+      data: {
+        id: '01KKWDA6BV6SGNQRFSMW5HEYSY',
+        connector_name: 'test-connector',
+        version: '2.0.0',
+        status: 'PENDING_VALIDATION',
+        reason: null
+      }
+    } as any)
+
+    await getProvisioningStatus('test-connector')
+
+    const callArgs = requestAPIStub.getCall(0)
+    expect(callArgs.args[0]).to.equal('/flowstate/connectors/private/test-connector/provisioning_status')
+    expect(callArgs.args[1].method).to.equal('GET')
+  })
+
+  it('should include reason when status is FAILED', async () => {
+    requestAPIStub = sinon.stub(request, 'requestAPI').resolves({
+      status: 200,
+      data: {
+        id: '01KKWDA6BV6SGNQRFSMW5HEYSY',
+        connector_name: 'my-connector',
+        version: '1.0.0',
+        status: 'FAILED',
+        reason: 'Invalid manifest schema'
+      }
+    } as any)
+
+    const result = await getProvisioningStatus('my-connector')
+
+    expect(result.status).to.equal('FAILED')
+    expect(result.reason).to.equal('Invalid manifest schema')
+  })
+
+  it('should throw an error when the API returns a non-200 status', async () => {
+    requestAPIStub = sinon.stub(request, 'requestAPI').resolves({
+      status: 404,
+      data: { error: 'Connector not found' }
+    } as any)
+
+    try {
+      await getProvisioningStatus('unknown-connector')
+      expect.fail('Should have thrown an error')
+    } catch (error) {
+      expect((error as Error).message).to.include('Failed to fetch provisioning status')
+      expect((error as Error).message).to.include('Connector not found')
+    }
+  })
+
+  it('should throw an error when the request fails', async () => {
+    requestAPIStub = sinon.stub(request, 'requestAPI').rejects(new Error('Network error'))
+
+    try {
+      await getProvisioningStatus('my-connector')
+      expect.fail('Should have thrown an error')
+    } catch (error) {
+      expect((error as Error).message).to.include('Network error')
+    }
+  })
+})

--- a/packages/zcli-connectors/src/lib/publish/status.ts
+++ b/packages/zcli-connectors/src/lib/publish/status.ts
@@ -1,0 +1,32 @@
+import { request } from '@zendesk/zcli-core'
+import type { ProvisioningStatus } from './poller'
+
+export interface ProvisioningStatusResult {
+  id: string
+  connectorName: string
+  version: string
+  status: ProvisioningStatus
+  reason?: string
+}
+
+export async function getProvisioningStatus (connectorName: string): Promise<ProvisioningStatusResult> {
+  const endpoint = `/flowstate/connectors/private/${connectorName}/provisioning_status`
+
+  const response = await request.requestAPI(endpoint, {
+    method: 'GET'
+  })
+
+  if (response.status !== 200) {
+    const errorDetails = response.data?.message || response.data?.error || JSON.stringify(response.data)
+    throw new Error(`Failed to fetch provisioning status: HTTP ${response.status} - ${errorDetails}`)
+  }
+
+  const data = response.data
+  return {
+    id: data.id,
+    connectorName: data.connector_name,
+    version: data.version,
+    status: data.status as ProvisioningStatus,
+    reason: data.reason ?? undefined
+  }
+}

--- a/packages/zcli-connectors/tests/functional/publish.test.ts
+++ b/packages/zcli-connectors/tests/functional/publish.test.ts
@@ -104,7 +104,7 @@ describe('publish command', () => {
       sinon.stub(publishModule, 'createConnector').resolves({
         uploadUrl: 'https://example.com/upload',
         connectorName: 'test-connector',
-        jobId: 'job-123'
+        provisioningId: 'job-123'
       })
 
       const uploadError = new Error('Failed to upload connector: S3 upload failed')
@@ -127,7 +127,7 @@ describe('publish command', () => {
         {
           uploadUrl: 'https://example.com/upload',
           connectorName: 'test-connector',
-          jobId: 'job-123'
+          provisioningId: 'job-123'
         }
       )
       sinon.stub(publishModule, 'uploadConnectorPackage').resolves()
@@ -149,7 +149,7 @@ describe('publish command', () => {
         {
           uploadUrl: 'https://example.com/upload',
           connectorName: 'test-connector',
-          jobId: 'job-123'
+          provisioningId: 'job-123'
         }
       )
       sinon.stub(publishModule, 'uploadConnectorPackage').resolves()
@@ -171,7 +171,7 @@ describe('publish command', () => {
         {
           uploadUrl: 'https://example.com/upload',
           connectorName: 'test-connector',
-          jobId: 'job-123'
+          provisioningId: 'job-123'
         }
       )
       sinon.stub(publishModule, 'uploadConnectorPackage').resolves()

--- a/packages/zcli-connectors/tests/functional/status.test.ts
+++ b/packages/zcli-connectors/tests/functional/status.test.ts
@@ -1,0 +1,315 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect, use } from 'chai'
+import * as sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import * as path from 'path'
+import * as fs from 'fs'
+import PublishStatusCommand from '../../src/commands/connectors/publish/status'
+import * as statusModule from '../../src/lib/publish/status'
+import type { ProvisioningStatus } from '../../src/lib/publish/poller'
+
+use(sinonChai)
+
+describe('publish:status', () => {
+  let statusCommand: PublishStatusCommand
+  let logStub: sinon.SinonStub
+  let errorStub: sinon.SinonStub
+  let fsStubs: {
+    existsSync: sinon.SinonStub
+    readFileSync: sinon.SinonStub
+  }
+
+  beforeEach(() => {
+    statusCommand = new PublishStatusCommand([], {} as any)
+    logStub = sinon.stub(statusCommand, 'log')
+    errorStub = sinon.stub(statusCommand, 'error').callsFake((message: unknown) => {
+      throw new Error(String(message))
+    })
+
+    fsStubs = {
+      existsSync: sinon.stub(fs, 'existsSync'),
+      readFileSync: sinon.stub(fs, 'readFileSync')
+    }
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('command configuration', () => {
+    it('should have correct description', () => {
+      expect(PublishStatusCommand.description).to.equal('check the provisioning status of a published connector')
+    })
+
+    it('should have help flag', () => {
+      expect(PublishStatusCommand.flags.help).to.exist
+    })
+
+    it('should have path argument with correct default', () => {
+      expect(PublishStatusCommand.args).to.have.length(1)
+      expect(PublishStatusCommand.args[0].name).to.equal('path')
+      expect(PublishStatusCommand.args[0].required).to.equal(false)
+      expect(PublishStatusCommand.args[0].default).to.equal('.')
+    })
+
+    it('should have correct examples', () => {
+      expect(PublishStatusCommand.examples).to.include.members([
+        '<%= config.bin %> <%= command.id %>',
+        '<%= config.bin %> <%= command.id %> ./example-connector'
+      ])
+    })
+  })
+
+  describe('status check flow', () => {
+    beforeEach(() => {
+      sinon.stub(statusCommand, 'parse' as any).resolves({
+        args: { path: '.' }
+      })
+    })
+
+    it('should successfully check status when manifest.json exists in dist directory', async () => {
+      const mockManifest = { name: 'test-connector', version: '1.0.0' }
+      const mockStatus = {
+        id: '01KKWDA6BV6SGNQRFSMW5HEYSY',
+        connectorName: 'test-connector',
+        version: '1.0.0',
+        status: 'SUCCESS' as ProvisioningStatus,
+        reason: undefined
+      }
+
+      // Both dist directory and manifest.json should exist
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns(JSON.stringify(mockManifest))
+      sinon.stub(statusModule, 'getProvisioningStatus').resolves(mockStatus)
+
+      await statusCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Status: Provisioned/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/test-connector.*v1\.0\.0/))
+    })
+
+    it('should display different status types correctly', async () => {
+      const mockManifest = { name: 'test-connector', version: '1.0.0' }
+
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns(JSON.stringify(mockManifest))
+
+      const pendingUploadStatus = {
+        id: '01KKWDA6BV6SGNQRFSMW5HEYSY',
+        connectorName: 'test-connector',
+        version: '1.0.0',
+        status: 'PENDING_UPLOAD' as ProvisioningStatus,
+        reason: undefined
+      }
+      sinon.stub(statusModule, 'getProvisioningStatus').resolves(pendingUploadStatus)
+
+      await statusCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Status: Waiting for upload/))
+    })
+
+    it('should display failed status with reason', async () => {
+      const mockManifest = { name: 'test-connector', version: '1.0.0' }
+
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns(JSON.stringify(mockManifest))
+
+      const failedStatus = {
+        id: 'job-123',
+        connectorName: 'test-connector',
+        version: '1.0.0',
+        status: 'FAILED' as ProvisioningStatus,
+        reason: 'Invalid manifest schema'
+      }
+      sinon.stub(statusModule, 'getProvisioningStatus').resolves(failedStatus)
+
+      await statusCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Status: Failed/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/Invalid manifest schema/))
+    })
+  })
+
+  describe('path handling', () => {
+    it('should resolve relative paths correctly', async () => {
+      const testPath = './my-connector'
+      const resolvedPath = path.resolve(testPath)
+      const distPath = path.join(resolvedPath, 'dist')
+      const manifestPath = path.join(resolvedPath, 'dist', 'manifest.json')
+
+      const mockManifest = { name: 'my-connector', version: '1.0.0' }
+
+      sinon.stub(statusCommand, 'parse' as any).resolves({
+        args: { path: testPath }
+      })
+
+      fsStubs.existsSync.callsFake((filePath: string) => {
+        return filePath === distPath || filePath === manifestPath
+      })
+      fsStubs.readFileSync.withArgs(manifestPath, 'utf-8').returns(JSON.stringify(mockManifest))
+
+      const mockStatus = {
+        id: 'job-123',
+        connectorName: 'my-connector',
+        version: '1.0.0',
+        status: 'SUCCESS' as ProvisioningStatus,
+        reason: undefined
+      }
+      sinon.stub(statusModule, 'getProvisioningStatus').resolves(mockStatus)
+
+      await statusCommand.run()
+
+      expect(fsStubs.readFileSync).to.have.been.calledWith(manifestPath, 'utf-8')
+    })
+
+    it('should handle absolute paths correctly', async () => {
+      const testPath = path.resolve('/', 'absolute', 'path', 'to', 'connector')
+      const distPath = path.join(testPath, 'dist')
+      const manifestPath = path.join(testPath, 'dist', 'manifest.json')
+
+      const mockManifest = { name: 'abs-connector', version: '2.0.0' }
+
+      sinon.stub(statusCommand, 'parse' as any).resolves({
+        args: { path: testPath }
+      })
+
+      fsStubs.existsSync.callsFake((filePath: string) => {
+        const normalizedFilePath = path.normalize(filePath)
+        const normalizedDistPath = path.normalize(distPath)
+        const normalizedManifestPath = path.normalize(manifestPath)
+        return normalizedFilePath === normalizedDistPath || normalizedFilePath === normalizedManifestPath
+      })
+      fsStubs.readFileSync.withArgs(manifestPath, 'utf-8').returns(JSON.stringify(mockManifest))
+
+      const mockStatus = {
+        id: 'job-456',
+        connectorName: 'abs-connector',
+        version: '2.0.0',
+        status: 'PENDING_VALIDATION' as ProvisioningStatus,
+        reason: undefined
+      }
+      sinon.stub(statusModule, 'getProvisioningStatus').resolves(mockStatus)
+
+      await statusCommand.run()
+
+      expect(fsStubs.readFileSync).to.have.been.calledWith(manifestPath, 'utf-8')
+    })
+  })
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      sinon.stub(statusCommand, 'parse' as any).resolves({
+        args: { path: '.' }
+      })
+    })
+
+    it('should error when dist directory does not exist', async () => {
+      fsStubs.existsSync.returns(false)
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[0]).to.match(/dist directory not found/)
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+
+    it('should error when manifest.json does not exist in dist directory', async () => {
+      const connectorPath = path.resolve('.')
+      const distPath = path.join(connectorPath, 'dist')
+      const manifestPath = path.join(distPath, 'manifest.json')
+
+      fsStubs.existsSync.callsFake((filePath: string) => {
+        if (filePath === distPath) return true
+        if (filePath === manifestPath) return false
+        return false
+      })
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[0]).to.match(/manifest\.json not found/)
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+
+    it('should error when manifest.json cannot be read', async () => {
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.throws(new Error('Permission denied'))
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[0]).to.match(/Error reading manifest\.json.*Permission denied/)
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+
+    it('should error when manifest.json contains invalid JSON', async () => {
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns('not valid json {{{')
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[0]).to.match(/Error reading manifest\.json/)
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+
+    it('should error when connector name is missing from manifest.json', async () => {
+      const mockManifest = { version: '1.0.0' }
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns(JSON.stringify(mockManifest))
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[0]).to.match(/Connector name not found in manifest\.json/)
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+
+    it('should error when getProvisioningStatus throws an Error', async () => {
+      const mockManifest = { name: 'my-connector', version: '1.0.0' }
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns(JSON.stringify(mockManifest))
+      sinon.stub(statusModule, 'getProvisioningStatus').rejects(new Error('Network error'))
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[0]).to.equal('Network error')
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+
+    it('should error when getProvisioningStatus throws a non-Error value', async () => {
+      const mockManifest = { name: 'my-connector', version: '1.0.0' }
+      fsStubs.existsSync.returns(true)
+      fsStubs.readFileSync.returns(JSON.stringify(mockManifest))
+      sinon.stub(statusModule, 'getProvisioningStatus').rejects('unexpected string error')
+
+      try {
+        await statusCommand.run()
+        expect.fail('Expected statusCommand.run() to throw an error')
+      } catch (error) {
+        expect(errorStub).to.have.been.calledOnce
+        expect(errorStub.firstCall.args[1]).to.deep.equal({ exit: 1 })
+      }
+    })
+  })
+})


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Adds `connectors:publish:status` command that fetches and displays the current provisioning status of a connector that has been published to Zendesk.  It automatically reads the connector name from the manifest.json file in the dist directory and queries the provisioning system to show the current state.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`8c0ad73`](https://github.com/zendesk/zcli/pull/320/commits/8c0ad73682ce4ef447bb27883c4095b36aade521) Adds the status command to connectors namespace



<!-- === GH HISTORY FENCE === -->

## Detail
JIRA: https://zendesk.atlassian.net/browse/VEG-3645
<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
