### PR TITLE
fix: missing dependencies when running connectors:bundle

### DIFF
--- a/packages/zcli-connectors/package.json
+++ b/packages/zcli-connectors/package.json
@@ -17,6 +17,7 @@
     "type:check": "tsc"
   },
   "dependencies": {
+    "@babel/preset-env": "^7.0.0",
     "@rollup/plugin-babel": "^6.0.0",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/zcli-connectors/src/lib/vite/vite-config.ts
+++ b/packages/zcli-connectors/src/lib/vite/vite-config.ts
@@ -41,7 +41,7 @@ export class ViteConfigBuilder {
     return babel({
       babelHelpers: 'bundled',
       presets: [
-        ['@babel/preset-env', { targets: { ie: '11' }, modules: false }]
+        [require.resolve('@babel/preset-env'), { targets: { ie: '11' }, modules: false }]
       ],
       extensions: ['.js', '.ts']
     })


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`cab8c95`](https://github.com/zendesk/zcli/pull/321/commits/cab8c95948f6220a418ff9417f590d42c888719c) fix: missing dependencies when running connectors:bundle

```
~/Code/zendesk » zcli connectors:bundle test-connector                                                                                                                                                           130 ↵ peter.nguyen@KHRP49XN6Y
✔ TypeScript compilation check passed
⠋ Bundling connector from /Users/peter.nguyen/Code/zendesk/test-connector to /Users/peter.nguyen/Code/zendesk/test-connector/dist...vite v7.3.1 building client environment for production...
✓ 0 modules transformed.
✗ Build failed in 26ms
Vite build failed: [babel] Cannot find package '@babel/preset-env' imported from /Users/peter.nguyen/Code/zendesk/babel-virtual-resolve-base.js
file: /Users/peter.nguyen/Code/zendesk/test-connector/src/index.ts
    at captureLargerStackTrace (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/vendor/import-meta-resolve.js:516:11)
    at new NodeError (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/vendor/import-meta-resolve.js:460:5)
    at packageResolve (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/vendor/import-meta-resolve.js:1970:9)
    at moduleResolve (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/vendor/import-meta-resolve.js:2048:18)
    at defaultResolve (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/vendor/import-meta-resolve.js:2224:15)
    at resolve (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/vendor/import-meta-resolve.js:2262:12)
    at tryImportMetaResolve (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/files/plugins.ts:154:51)
    at resolveStandardizedNameForImport (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/files/plugins.ts:184:19)
    at resolvePreset (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/files/plugins.ts:200:22)
    at resolver (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/files/plugins.ts:50:32)
    at loadPreset.next (<anonymous>)
    at createDescriptor (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-descriptors.ts:325:35)
    at createDescriptor.next (<anonymous>)
    at step (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:261:32)
    at evaluateAsync (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:291:5)
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:44:11
    at Array.forEach (<anonymous>)
    at Function.async (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:43:15)
    at Function.all (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:216:13)
    at Generator.next (<anonymous>)
    at createDescriptors (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-descriptors.ts:266:38)
    at createDescriptors.next (<anonymous>)
    at createPresetDescriptors (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-descriptors.ts:240:17)
    at createPresetDescriptors.next (<anonymous>)
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-descriptors.ts:155:36
    at Generator.next (<anonymous>)
    at Function.<anonymous> (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/gensync-utils/async.ts:10:3)
    at Generator.next (<anonymous>)
    at step (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:269:25)
    at evaluateAsync (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:291:5)
    at Function.errback (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:113:7)
    at errback (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/gensync-utils/async.ts:88:18)
    at async (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:188:17)
    at onFirstPause (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:216:13)
    at Generator.next (<anonymous>)
    at presets (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/caching.ts:131:34)
    at cachedFunction.next (<anonymous>)
    at mergeChainOpts (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-chain.ts:727:34)
    at mergeChainOpts.next (<anonymous>)
    at loadProgrammaticChain (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-chain.ts:663:14)
    at chainWalker.next (<anonymous>)
    at buildRootChain (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/config-chain.ts:151:36)
    at buildRootChain.next (<anonymous>)
    at loadPrivatePartialConfig (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/partial.ts:110:44)
    at loadPrivatePartialConfig.next (<anonymous>)
    at loadPartialConfig (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/config/partial.ts:169:12)
    at loadPartialConfig.next (<anonymous>)
    at step (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:269:25)
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:273:13
    at async.call.result.err.err (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:223:11)
    at cb (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:189:28)
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/@babel/core/src/gensync-utils/async.ts:90:7
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:113:33
    at step (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:287:14)
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:273:13
    at async.call.result.err.err (/Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:223:11)
    at /Users/peter.nguyen/Code/zendesk/zcli/node_modules/gensync/index.js:37:40
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 'PLUGIN_ERROR',
  pluginCode: 'ERR_MODULE_NOT_FOUND',
  plugin: 'babel',
  hook: 'transform',
  id: '/Users/peter.nguyen/Code/zendesk/test-connector/src/index.ts',
  watchFiles: [ '/Users/peter.nguyen/Code/zendesk/test-connector/src/index.ts' ]
}
✖ Bundle failed with errors!
Found 1 error(s)
Error: [babel] Cannot find package '@babel/preset-env' imported from /Users/peter.nguyen/Code/zendesk/babel-virtual-resolve-base.js
file: /Users/peter.nguyen/Code/zendesk/test-connector/src/index.ts
✖ Failed to bundle the connector
 ›   Error: Connector build failed

```



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
