### PR TITLE
[APPS-8078]Chore:npm publish - release PR workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,28 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: zendesk/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: zendesk/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "yarn"
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run release script
+        run: bash scripts/create-release-pr.sh

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -120,11 +120,6 @@ export default class List extends Command {
     this.log(chalk.green(`\nFound ${connectors.length} connector(s):\n`))
 
     CliUx.ux.table(connectors, {
-      connector_nice_id: {
-        header: 'ID',
-        minWidth: 25,
-        get: (row: ConnectorListItem) => row.connector_nice_id || row.connector_name
-      },
       title: {
         header: 'Title',
         minWidth: 30,
@@ -132,7 +127,8 @@ export default class List extends Command {
       },
       connector_name: {
         header: 'Connector Name',
-        minWidth: 25
+        minWidth: 25,
+        get: (row: ConnectorListItem) => row.connector_nice_id || row.connector_name
       },
       version: {
         header: 'Version',

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -43,7 +43,7 @@ export default class List extends Command {
     const { flags } = await this.parse(List)
 
     if (flags.verbose) {
-      this.log(chalk.cyan('Verbose mode enabled'))
+      this.logVerbose('Verbose mode enabled', flags.json)
     }
 
     const spinner = ora('Fetching connectors...').start()
@@ -56,8 +56,8 @@ export default class List extends Command {
       spinner.stop()
 
       if (flags.verbose) {
-        this.log(chalk.cyan(`API response status: ${response.status}`))
-        this.log(chalk.cyan(`Response data: ${JSON.stringify(response.data, null, 2)}`))
+        this.logVerbose(`API response status: ${response.status}`, flags.json)
+        this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`, flags.json)
       }
 
       const data = response.data as ListConnectorsResponse
@@ -76,28 +76,53 @@ export default class List extends Command {
 
       // Non-JSON output mode
       if (response.status !== 200) {
-        this.log(chalk.red(`API returned non-200 status: ${response.status}`))
-        this.log(chalk.yellow('Response data:'), JSON.stringify(response.data, null, 2))
+        const errorMsg = `API returned non-200 status: ${response.status}`
+        const responseData = JSON.stringify(response.data, null, 2)
+
+        if (flags.json) {
+          // In JSON mode, write error details to stderr
+          process.stderr.write(chalk.red(errorMsg) + '\n')
+          process.stderr.write(chalk.yellow('Response data: ') + responseData + '\n')
+        } else {
+          this.log(chalk.red(errorMsg))
+          this.log(chalk.yellow('Response data:'), responseData)
+        }
         return
       }
 
       if (!data.connectors || data.connectors.length === 0) {
-        this.log(chalk.yellow('No connectors found'))
+        if (flags.json) {
+          this.log(JSON.stringify([], null, 2))
+        } else {
+          this.log(chalk.yellow('No connectors found'))
+        }
         return
       }
 
       this.displayTable(data.connectors)
     } catch (error) {
-      spinner.fail(chalk.red('Failed to fetch connectors'))
+      if (!flags.json) {
+        spinner.fail(chalk.red('Failed to fetch connectors'))
+      }
 
       const errorMessage = (error instanceof Error) ? error.message : String(error)
 
       if (flags.verbose) {
-        this.log('\n' + chalk.red('Error Details:'))
-        this.log(errorMessage)
+        this.logVerbose('\nError Details:', flags.json, 'red')
+        this.logVerbose(errorMessage, flags.json)
       }
 
       this.error(errorMessage, { exit: 1 })
+    }
+  }
+
+  private logVerbose (message: string, isJsonMode: boolean, color?: 'cyan' | 'red'): void {
+    const coloredMessage = color ? chalk[color](message) : chalk.cyan(message)
+    if (isJsonMode) {
+      // Write to stderr to avoid corrupting JSON output on stdout
+      process.stderr.write(coloredMessage + '\n')
+    } else {
+      this.log(coloredMessage)
     }
   }
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -1,0 +1,137 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import * as chalk from 'chalk'
+import * as ora from 'ora'
+import { request } from '@zendesk/zcli-core'
+
+interface ConnectorListItem {
+  connector_name: string
+  connector_nice_id: string | null
+  title: string | null
+  version: string
+  description: string | null
+  created_at: string
+  updated_at: string
+  [key: string]: string | null
+}
+
+interface ListConnectorsResponse {
+  connectors: ConnectorListItem[]
+}
+
+export default class List extends Command {
+  static description = 'list all private connectors for the current account'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --json'
+  ]
+
+  static flags = {
+    help: Flags.help({ char: 'h' }),
+    json: Flags.boolean({
+      description: 'output in JSON format',
+      default: false
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'verbose output',
+      default: false
+    })
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(List)
+
+    if (flags.verbose) {
+      this.log(chalk.cyan('Verbose mode enabled'))
+    }
+
+    const spinner = ora('Fetching connectors...').start()
+
+    try {
+      const response = await request.requestAPI('/flowstate/connectors/private/list', {
+        method: 'GET'
+      })
+
+      spinner.stop()
+
+      if (flags.verbose) {
+        this.log(chalk.cyan(`API response status: ${response.status}`))
+        this.log(chalk.cyan(`Response data: ${JSON.stringify(response.data, null, 2)}`))
+      }
+
+      // Check for non-200 status
+      if (response.status !== 200) {
+        this.log(chalk.red(`API returned non-200 status: ${response.status}`))
+        this.log(chalk.yellow('Response data:'), JSON.stringify(response.data, null, 2))
+        return
+      }
+
+      const data = response.data as ListConnectorsResponse
+
+      if (!data.connectors || data.connectors.length === 0) {
+        this.log(chalk.yellow('No connectors found'))
+        return
+      }
+
+      if (flags.json) {
+        this.log(JSON.stringify(data.connectors, null, 2))
+      } else {
+        this.displayTable(data.connectors)
+      }
+    } catch (error) {
+      spinner.fail(chalk.red('Failed to fetch connectors'))
+
+      const errorMessage = (error instanceof Error) ? error.message : String(error)
+
+      if (flags.verbose) {
+        this.log('\n' + chalk.red('Error Details:'))
+        this.log(errorMessage)
+      }
+
+      this.error(errorMessage, { exit: 1 })
+    }
+  }
+
+  private displayTable (connectors: ConnectorListItem[]): void {
+    this.log(chalk.green(`\nFound ${connectors.length} connector(s):\n`))
+
+    CliUx.ux.table(connectors, {
+      connector_nice_id: {
+        header: 'ID',
+        minWidth: 25,
+        get: (row: ConnectorListItem) => row.connector_nice_id || row.connector_name
+      },
+      title: {
+        header: 'Title',
+        minWidth: 30,
+        get: (row: ConnectorListItem) => row.title || row.connector_name
+      },
+      connector_name: {
+        header: 'Connector Name',
+        minWidth: 25
+      },
+      version: {
+        header: 'Version',
+        minWidth: 10
+      },
+      description: {
+        header: 'Description',
+        minWidth: 35,
+        get: (row: ConnectorListItem) => row.description || '-'
+      },
+      created_at: {
+        header: 'Created',
+        minWidth: 20,
+        get: (row: ConnectorListItem) => new Date(row.created_at).toLocaleString()
+      },
+      updated_at: {
+        header: 'Updated',
+        minWidth: 20,
+        get: (row: ConnectorListItem) => new Date(row.updated_at).toLocaleString()
+      }
+    }, {
+      printLine: this.log.bind(this)
+    })
+  }
+}

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -68,6 +68,12 @@ export default class List extends Command {
           // Route error to stderr and exit via outer catch; no human-readable output on stdout
           throw new Error(`API returned non-200 status: ${response.status}`)
         }
+
+        const connectors = data.connectors ?? []
+        this.log(JSON.stringify(connectors, null, 2))
+        return
+      }
+
       // Non-JSON output mode: handle non-200 responses with human-readable output
       if (response.status !== 200) {
         const errorMsg = `API returned non-200 status: ${response.status}`
@@ -86,7 +92,7 @@ export default class List extends Command {
       this.displayTable(data.connectors)
     } catch (error) {
       if (!flags.json) {
-        spinner.fail(chalk.red('Failed to fetch connectors'))
+        spinner?.fail(chalk.red('Failed to fetch connectors'))
       }
 
       const errorMessage = (error instanceof Error) ? error.message : String(error)

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -46,14 +46,14 @@ export default class List extends Command {
       this.logVerbose('Verbose mode enabled', flags.json)
     }
 
-    const spinner = ora('Fetching connectors...').start()
+    const spinner = flags.json ? null : ora('Fetching connectors...').start()
 
     try {
       const response = await request.requestAPI('/flowstate/connectors/private/list', {
         method: 'GET'
       })
 
-      spinner.stop()
+      spinner?.stop()
 
       if (flags.verbose) {
         this.logVerbose(`API response status: ${response.status}`, flags.json)
@@ -76,18 +76,12 @@ export default class List extends Command {
 
       // Non-JSON output mode
       if (response.status !== 200) {
-        const errorMsg = `API returned non-200 status: ${response.status}`
-        const responseData = JSON.stringify(response.data, null, 2)
+        const baseErrorMsg = `API returned non-200 status: ${response.status}`
+        const verboseSuffix = flags.verbose
+          ? '\n' + chalk.yellow('Response data: ') + JSON.stringify(response.data, null, 2)
+          : ''
 
-        if (flags.json) {
-          // In JSON mode, write error details to stderr
-          process.stderr.write(chalk.red(errorMsg) + '\n')
-          process.stderr.write(chalk.yellow('Response data: ') + responseData + '\n')
-        } else {
-          this.log(chalk.red(errorMsg))
-          this.log(chalk.yellow('Response data:'), responseData)
-        }
-        return
+        this.error(baseErrorMsg + verboseSuffix, { exit: 1 })
       }
 
       if (!data.connectors || data.connectors.length === 0) {

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -131,12 +131,12 @@ export default class List extends Command {
       created_at: {
         header: 'Created',
         minWidth: 20,
-        get: (row: ConnectorListItem) => new Date(row.created_at).toLocaleString()
+        get: (row: ConnectorListItem) => row.created_at
       },
       updated_at: {
         header: 'Updated',
         minWidth: 20,
-        get: (row: ConnectorListItem) => new Date(row.updated_at).toLocaleString()
+        get: (row: ConnectorListItem) => row.updated_at
       }
     }, {
       printLine: this.log.bind(this)

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -49,7 +49,7 @@ export default class List extends Command {
     const spinner = flags.json ? null : ora('Fetching connectors...').start()
 
     try {
-      const response = await request.requestAPI('/flowstate/connectors/private/list', {
+      const response = await request.requestAPI('/flowstate/connectors/private', {
         method: 'GET'
       })
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -68,28 +68,18 @@ export default class List extends Command {
           // Route error to stderr and exit via outer catch; no human-readable output on stdout
           throw new Error(`API returned non-200 status: ${response.status}`)
         }
+      // Non-JSON output mode: handle non-200 responses with human-readable output
+      if (response.status !== 200) {
+        const errorMsg = `API returned non-200 status: ${response.status}`
+        const responseData = JSON.stringify(response.data, null, 2)
 
-        const connectors = data.connectors ?? []
-        this.log(JSON.stringify(connectors, null, 2))
+        this.log(chalk.red(errorMsg))
+        this.log(chalk.yellow('Response data:'), responseData)
         return
       }
 
-      // Non-JSON output mode
-      if (response.status !== 200) {
-        const baseErrorMsg = `API returned non-200 status: ${response.status}`
-        const verboseSuffix = flags.verbose
-          ? '\n' + chalk.yellow('Response data: ') + JSON.stringify(response.data, null, 2)
-          : ''
-
-        this.error(baseErrorMsg + verboseSuffix, { exit: 1 })
-      }
-
       if (!data.connectors || data.connectors.length === 0) {
-        if (flags.json) {
-          this.log(JSON.stringify([], null, 2))
-        } else {
-          this.log(chalk.yellow('No connectors found'))
-        }
+        this.log(chalk.yellow('No connectors found'))
         return
       }
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -15,7 +15,7 @@ interface ConnectorListItem {
 }
 
 interface ListConnectorsResponse {
-  connectors: ConnectorListItem[]
+  connectors?: ConnectorListItem[]
 }
 
 export default class List extends Command {
@@ -65,8 +65,8 @@ export default class List extends Command {
       // JSON output mode: always emit JSON to stdout
       if (flags.json) {
         if (response.status !== 200) {
-          // Route error to stderr and exit; no human-readable output on stdout
-          this.error(`API returned non-200 status: ${response.status}`, { exit: 1 })
+          // Route error to stderr and exit via outer catch; no human-readable output on stdout
+          throw new Error(`API returned non-200 status: ${response.status}`)
         }
 
         const connectors = data.connectors ?? []

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -60,25 +60,33 @@ export default class List extends Command {
         this.log(chalk.cyan(`Response data: ${JSON.stringify(response.data, null, 2)}`))
       }
 
-      // Check for non-200 status
+      const data = response.data as ListConnectorsResponse
+
+      // JSON output mode: always emit JSON to stdout
+      if (flags.json) {
+        if (response.status !== 200) {
+          // Route error to stderr and exit; no human-readable output on stdout
+          this.error(`API returned non-200 status: ${response.status}`, { exit: 1 })
+        }
+
+        const connectors = data.connectors ?? []
+        this.log(JSON.stringify(connectors, null, 2))
+        return
+      }
+
+      // Non-JSON output mode
       if (response.status !== 200) {
         this.log(chalk.red(`API returned non-200 status: ${response.status}`))
         this.log(chalk.yellow('Response data:'), JSON.stringify(response.data, null, 2))
         return
       }
 
-      const data = response.data as ListConnectorsResponse
-
       if (!data.connectors || data.connectors.length === 0) {
         this.log(chalk.yellow('No connectors found'))
         return
       }
 
-      if (flags.json) {
-        this.log(JSON.stringify(data.connectors, null, 2))
-      } else {
-        this.displayTable(data.connectors)
-      }
+      this.displayTable(data.connectors)
     } catch (error) {
       spinner.fail(chalk.red('Failed to fetch connectors'))
 

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -13,6 +13,7 @@ describe('list command', () => {
   let logStub: sinon.SinonStub
   let requestAPIStub: sinon.SinonStub
   let stderrWriteStub: sinon.SinonStub
+  let parseStub: sinon.SinonStub
 
   const mockConnectorData = [
     {
@@ -67,7 +68,7 @@ describe('list command', () => {
 
   describe('successful list operations', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,
@@ -126,7 +127,7 @@ describe('list command', () => {
 
   describe('JSON output mode', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: false,
@@ -184,7 +185,7 @@ describe('list command', () => {
 
   describe('verbose mode', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: true,
@@ -206,7 +207,8 @@ describe('list command', () => {
     })
 
     it('should log verbose messages to stderr in JSON mode', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: true,
@@ -235,7 +237,7 @@ describe('list command', () => {
 
   describe('error handling - non-200 responses', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,
@@ -267,7 +269,8 @@ describe('list command', () => {
     })
 
     it('should route non-200 errors to stderr in JSON mode', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: false,
@@ -275,16 +278,28 @@ describe('list command', () => {
         }
       })
 
+      const errorStub = sinon.stub(listCommand, 'error').callsFake((message: any) => {
+        const err = new Error(String(message))
+        throw err
+      })
+
       requestAPIStub.resolves({
         status: 404,
         data: { error: 'Not Found' }
       })
 
-      await listCommand.run()
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected to throw
+      }
 
-      // Error should go to stderr in JSON mode
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 404/))
-      expect(logStub).to.not.have.been.called
+      // Error should go through this.error() in JSON mode
+      expect(errorStub).to.have.been.calledWith(
+        'API returned non-200 status: 404',
+        sinon.match({ exit: 1 })
+      )
     })
   })
 
@@ -293,7 +308,7 @@ describe('list command', () => {
     let caughtError: Error | undefined
 
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,
@@ -349,7 +364,8 @@ describe('list command', () => {
     })
 
     it('should log verbose error details when verbose flag is set', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: true,
@@ -372,7 +388,8 @@ describe('list command', () => {
     })
 
     it('should route verbose error details to stderr in JSON mode', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: true,
@@ -398,7 +415,7 @@ describe('list command', () => {
 
   describe('API response edge cases', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -1,0 +1,443 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect, use } from 'chai'
+import * as sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import ListCommand from '../../src/commands/connectors/list'
+import { request } from '@zendesk/zcli-core'
+
+use(sinonChai)
+
+describe('list command', () => {
+  let listCommand: ListCommand
+  let logStub: sinon.SinonStub
+  let requestAPIStub: sinon.SinonStub
+  let stderrWriteStub: sinon.SinonStub
+
+  const mockConnectorData = [
+    {
+      connector_name: 'test-connector-1',
+      connector_nice_id: 'nice-id-1',
+      title: 'Test Connector 1',
+      version: '1.0.0',
+      description: 'A test connector',
+      created_at: '2026-03-01T00:00:00Z',
+      updated_at: '2026-03-15T00:00:00Z'
+    },
+    {
+      connector_name: 'test-connector-2',
+      connector_nice_id: 'nice-id-2',
+      title: 'Test Connector 2',
+      version: '2.1.0',
+      description: null,
+      created_at: '2026-03-10T00:00:00Z',
+      updated_at: '2026-03-20T00:00:00Z'
+    }
+  ]
+
+  beforeEach(() => {
+    listCommand = new ListCommand([], {} as any)
+    logStub = sinon.stub(listCommand, 'log')
+    requestAPIStub = sinon.stub(request, 'requestAPI')
+    stderrWriteStub = sinon.stub(process.stderr, 'write')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('command flags', () => {
+    it('should have help flag', () => {
+      expect(ListCommand.flags.help).to.exist
+    })
+
+    it('should have json flag', () => {
+      expect(ListCommand.flags.json).to.exist
+      expect(ListCommand.flags.json.type).to.equal('boolean')
+      expect(ListCommand.flags.json.default).to.equal(false)
+    })
+
+    it('should have verbose flag with char v', () => {
+      expect(ListCommand.flags.verbose).to.exist
+      expect(ListCommand.flags.verbose.char).to.equal('v')
+      expect(ListCommand.flags.verbose.type).to.equal('boolean')
+      expect(ListCommand.flags.verbose.default).to.equal(false)
+    })
+  })
+
+  describe('successful list operations', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should successfully list connectors in table format', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      expect(requestAPIStub).to.have.been.calledWith('/flowstate/connectors/private/list', {
+        method: 'GET'
+      })
+      expect(logStub).to.have.been.calledWith(sinon.match(/Found 2 connector/))
+    })
+
+    it('should display empty list message when no connectors exist', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: [] }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+
+    it('should handle connectors with null values gracefully', async () => {
+      const connectorWithNulls = [{
+        connector_name: 'test-connector',
+        connector_nice_id: null,
+        title: null,
+        version: '1.0.0',
+        description: null,
+        created_at: '2026-03-01T00:00:00Z',
+        updated_at: '2026-03-15T00:00:00Z'
+      }]
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: connectorWithNulls }
+      })
+
+      await listCommand.run()
+
+      expect(requestAPIStub).to.have.been.called
+      expect(logStub).to.have.been.calledWith(sinon.match(/Found 1 connector/))
+    })
+  })
+
+  describe('JSON output mode', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should output JSON format when --json flag is set', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      const parsedOutput = JSON.parse(outputArg)
+
+      expect(parsedOutput).to.be.an('array')
+      expect(parsedOutput).to.have.lengthOf(2)
+      expect(parsedOutput[0]).to.have.property('connector_name', 'test-connector-1')
+      expect(parsedOutput[1]).to.have.property('connector_name', 'test-connector-2')
+    })
+
+    it('should output empty JSON array when no connectors exist', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: [] }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      const parsedOutput = JSON.parse(outputArg)
+
+      expect(parsedOutput).to.be.an('array')
+      expect(parsedOutput).to.have.lengthOf(0)
+    })
+
+    it('should not output spinner in JSON mode', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      // In JSON mode, no spinner-related logs should be on stdout
+      expect(logStub).to.have.been.calledOnce
+    })
+  })
+
+  describe('verbose mode', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: true,
+          help: false
+        }
+      })
+    })
+
+    it('should log verbose messages to stdout in normal mode', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+    })
+
+    it('should log verbose messages to stderr in JSON mode', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: true,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      // Verbose logs should go to stderr, not stdout
+      expect(stderrWriteStub).to.have.been.called
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+
+      // Only JSON output should be on stdout
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      expect(() => JSON.parse(outputArg)).to.not.throw()
+    })
+  })
+
+  describe('error handling - non-200 responses', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should handle 403 Forbidden response', async () => {
+      requestAPIStub.resolves({
+        status: 403,
+        data: { error: 'Forbidden' }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 403/))
+    })
+
+    it('should handle 500 Internal Server Error response', async () => {
+      requestAPIStub.resolves({
+        status: 500,
+        data: { error: 'Internal Server Error' }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 500/))
+    })
+
+    it('should route non-200 errors to stderr in JSON mode', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: false,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 404,
+        data: { error: 'Not Found' }
+      })
+
+      await listCommand.run()
+
+      // Error should go to stderr in JSON mode
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 404/))
+      expect(logStub).to.not.have.been.called
+    })
+  })
+
+  describe('error handling - API failures', () => {
+    let errorStub: sinon.SinonStub
+    let caughtError: Error | undefined
+
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+
+      errorStub = sinon.stub(listCommand, 'error').callsFake((message: any, options: any) => {
+        const err = new Error(String(message))
+        ;(err as any).options = options
+        throw err
+      })
+    })
+
+    afterEach(() => {
+      caughtError = undefined
+    })
+
+    it('should handle network errors', async () => {
+      const networkError = new Error('Network request failed: ECONNREFUSED')
+      requestAPIStub.rejects(networkError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(caughtError).to.exist
+      expect(errorStub).to.have.been.calledWith(
+        'Network request failed: ECONNREFUSED',
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should handle authentication errors', async () => {
+      const authError = new Error('Authentication failed: Invalid credentials')
+      requestAPIStub.rejects(authError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(caughtError).to.exist
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Authentication failed/),
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should log verbose error details when verbose flag is set', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: true,
+          help: false
+        }
+      })
+
+      const detailedError = new Error('Detailed error message')
+      requestAPIStub.rejects(detailedError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Error Details:/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/Detailed error message/))
+    })
+
+    it('should route verbose error details to stderr in JSON mode', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: true,
+          help: false
+        }
+      })
+
+      const detailedError = new Error('Error in JSON mode')
+      requestAPIStub.rejects(detailedError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      // Verbose error details should go to stderr
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error Details:/))
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error in JSON mode/))
+    })
+  })
+
+  describe('API response edge cases', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should handle null connectors array', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: null }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+
+    it('should handle undefined connectors array', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+
+    it('should handle malformed response data', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: 'not an object'
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+  })
+})

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -85,7 +85,7 @@ describe('list command', () => {
 
       await listCommand.run()
 
-      expect(requestAPIStub).to.have.been.calledWith('/flowstate/connectors/private/list', {
+      expect(requestAPIStub).to.have.been.calledWith('/flowstate/connectors/private', {
         method: 'GET'
       })
       expect(logStub).to.have.been.calledWith(sinon.match(/Found 2 connector/))

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -96,8 +96,7 @@ echo ''
 npx lerna version \
   --conventional-commits \
   --no-git-tag-version \
-  --yes \
-  --preid 'beta'
+  --yes
 
 if [ $? -ne 0 ]; then
     echo ''
@@ -164,5 +163,5 @@ echo '2. Review the version bumps and changelog'
 echo '3. Merge the PR to trigger automated publishing'
 echo ''
 echo '⚠️  Publishing to npm will happen automatically when PR is merged!'
-echo '   Git tags will be created automatically during the merge process.'
+echo '   Git tags will be created automatically by the GitHub Actions workflow.'
 echo ''

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -95,6 +95,7 @@ echo ''
 # Tags will be created when PR is merged to master
 npx lerna version \
   --conventional-commits \
+  --conventional-graduate \
   --no-git-tag-version \
   --yes
 

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Creates a release PR using Lerna conventional commits
+# Publishing happens automatically when PR is merged via GitHub Actions
+#
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │                        RELEASE PR WORKFLOW                              │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+#   Developer (master)
+#        │
+#        ├─ 1. PRE-FLIGHT CHECKS ──────────────────────────────────┐
+#        │   • On master branch?                                   │
+#        │   • Working directory clean?                            │
+#        │                                                          │
+#        ├─ 2. SYNC & BRANCH ──────────────────────────────────────┤
+#        │   • git pull origin master                              │
+#        │   • git checkout -b release/pending-TIMESTAMP           │
+#        │                                                          │
+#        ├─ 3. INSTALL & VERSION ──────────────────────────────────┤
+#        │   • yarn install --frozen-lockfile                      │
+#        │   • lerna version --conventional-commits                │
+#        │     ┌─ Analyzes commits since last git tag:            │
+#        │     │  - feat: → MINOR bump (1.0.0 → 1.1.0)            │
+#        │     │  - fix: → PATCH bump (1.0.0 → 1.0.1)             │
+#        │     │  - BREAKING CHANGE: → MAJOR (1.0.0 → 2.0.0)      │
+#        │     │  - chore/docs/etc → No version change            │
+#        │     ├─ For each changed package:                       │
+#        │     │  • Updates package.json version                  │
+#        │     │  • Generates/updates CHANGELOG.md                │
+#        │     └─ Updates lerna.json with new version             │
+#        │   • Extract version from lerna.json → NEW_VERSION      │
+#        │                                                          │
+#        ├─ 4. COMMIT & RENAME ────────────────────────────────────┤
+#        │   • git commit -m "chore(release): publish X.X.X"       │
+#        │   • git branch -m release/X.X.X                         │
+#        │                                                          │
+#        ├─ 5. PUSH TO GITHUB ─────────────────────────────────────┤
+#        │   • git push origin release/X.X.X                       │
+#        │                                                          │
+#        └─ 6. SWITCH BACK ────────────────────────────────────────┘
+#            • git checkout master
+#
+#   Next Steps (Manual):
+#   ┌────────────────────────────────────────────────────────────┐
+#   │ 1. Create PR: release/X.X.X → master                       │
+#   │ 2. Review changes (version bumps, changelog)               │
+#   │ 3. Merge PR                                                 │
+#   │    └─> Triggers GitHub Actions: .github/workflows/publish.yml │
+#   │        • Publishes to npm (company service account)        │
+#   │        • Creates git tags                                  │
+#   └────────────────────────────────────────────────────────────┘
+#
+
+set -e
+
+echo "🚀 ZCLI Release PR Creator"
+echo "================================"
+echo ""
+
+# Pre-flight checks
+if [[ "$(git branch --show-current)" != "master" ]]; then
+    printf '❌ Error: Please run this from master branch\n'
+    exit 1
+fi
+
+if [[ -n $(git status --porcelain) ]]; then
+    printf '❌ Error: You have uncommitted changes. Please commit or stash them first.\n'
+    exit 1
+fi
+
+echo '🔄 Pulling latest changes from master...'
+git pull origin master
+
+echo '🌿 Creating temporary release branch...'
+# Create temporary branch - will be renamed after version is determined
+TEMP_BRANCH="release/pending-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$TEMP_BRANCH"
+
+echo '📦 Installing dependencies...'
+yarn install --frozen-lockfile
+
+echo ''
+echo '📝 Analyzing commits and determining version bump...'
+echo '   (using conventional commits since last release)'
+echo ''
+
+# Run lerna version without git operations
+# This will:
+# - Analyze commits since last tag
+# - Determine version bump (major/minor/patch)
+# - Update package.json files
+# - Update lerna.json
+# - Generate CHANGELOG.md files
+# Note: We use --no-git-tag-version to prevent tag creation
+# Tags will be created when PR is merged to master
+npx lerna version \
+  --conventional-commits \
+  --no-git-tag-version \
+  --yes \
+  --preid 'beta'
+
+if [ $? -ne 0 ]; then
+    echo ''
+    echo '❌ Lerna version failed. Cleaning up...'
+    git checkout master
+    git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+    exit 1
+fi
+
+# Get the new version
+NEW_VERSION=$(jq -r '.version' lerna.json)
+
+if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "null" ]; then
+    echo ''
+    echo '❌ Could not determine new version. Cleaning up...'
+    git checkout master
+    git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+    exit 1
+fi
+
+# Commit the version changes
+echo ''
+echo "✅ Version bumped to: $NEW_VERSION"
+echo '📝 Committing version changes...'
+git add .
+git commit -m "chore(release): publish $NEW_VERSION"
+
+# Rename branch to use the actual version
+RELEASE_BRANCH="release/$NEW_VERSION"
+echo "🔄 Renaming branch to: $RELEASE_BRANCH"
+git branch -m "$RELEASE_BRANCH"
+echo ''
+
+# Get list of changed packages
+echo '📦 Packages to be published:'
+npx lerna changed --json 2>/dev/null | jq -r '.[].name' | sed 's/^/   - /'
+echo ''
+
+# Push branch only
+echo '⬆️  Pushing branch to GitHub...'
+git push origin "$RELEASE_BRANCH"
+
+if [ $? -ne 0 ]; then
+    echo ''
+    echo '❌ Failed to push to GitHub. Please check your permissions.'
+    exit 1
+fi
+
+echo ''
+echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+echo '🎉 Release branch created successfully!'
+echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+echo ''
+echo "📋 Version: $NEW_VERSION"
+echo "🌿 Branch:  $RELEASE_BRANCH"
+echo ''
+echo 'Next steps:'
+echo '1. Open a PR: https://github.com/zendesk/zcli/compare/'$RELEASE_BRANCH'?expand=1'
+echo '2. Review the version bumps and changelog'
+echo '3. Merge the PR to trigger automated publishing'
+echo ''
+echo '⚠️  Publishing to npm will happen automatically when PR is merged!'
+echo '   Git tags will be created automatically during the merge process.'
+echo ''
+
+# Switch back to master branch
+echo '🔄 Switching back to master branch...'
+git checkout master
+echo ''

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -11,33 +11,41 @@
 #        ├─ 1. PRE-FLIGHT CHECKS ──────────────────────────────────┐
 #        │   • On master branch?                                   │
 #        │   • Working directory clean?                            │
-#        │                                                          │
+#        │                                                         │
 #        ├─ 2. SYNC & BRANCH ──────────────────────────────────────┤
 #        │   • git pull origin master                              │
 #        │   • git checkout -b release/pending-TIMESTAMP           │
-#        │                                                          │
+#        │                                                         │
 #        ├─ 3. INSTALL & VERSION ──────────────────────────────────┤
 #        │   • yarn install --frozen-lockfile                      │
+#        │   • Save current version from lerna.json                │
 #        │   • lerna version --conventional-commits                │
 #        │     ┌─ Analyzes commits since last git tag:            │
 #        │     │  - feat: → MINOR bump (1.0.0 → 1.1.0)            │
 #        │     │  - fix: → PATCH bump (1.0.0 → 1.0.1)             │
 #        │     │  - BREAKING CHANGE: → MAJOR (1.0.0 → 2.0.0)      │
-#        │     │  - chore/docs/etc → No version change            │
 #        │     ├─ For each changed package:                       │
 #        │     │  • Updates package.json version                  │
 #        │     │  • Generates/updates CHANGELOG.md                │
 #        │     └─ Updates lerna.json with new version             │
 #        │   • Extract version from lerna.json → NEW_VERSION      │
 #        │                                                          │
-#        ├─ 4. COMMIT & RENAME ────────────────────────────────────┤
-#        │   • git commit -m "chore(release): publish X.X.X"       │
-#        │   • git branch -m release/X.X.X                         │
+#        ├─ 4. VERSION CHECK ──────────────────────────────────────┤
+#        │   • Compare NEW_VERSION with the current version       │
+#        │   • If unchanged:                                      │
+#        │     ├─ Show info: "Nothing to release"                 │
+#        │     ├─ Cleanup: checkout master, delete temp branch    │
+#        │     └─ Exit 0 (success, no release needed)             │
+#        │   • If changed: Continue to next step                  │
 #        │                                                          │
-#        ├─ 5. PUSH TO GITHUB ─────────────────────────────────────┤
+#        ├─ 5. COMMIT & RENAME ────────────────────────────────────┤
+#        │   • git commit -m "chore(release): publish X.X.X"       │
+#        │   • git branch -m release/X.X.X                           │
+#        │                                                          │
+#        ├─ 6. PUSH TO GITHUB ─────────────────────────────────────┤
 #        │   • git push origin release/X.X.X                       │
 #        │                                                          │
-#        └─ 6. SWITCH BACK ────────────────────────────────────────┘
+#        └─ 7. SWITCH BACK ────────────────────────────────────────┘
 #            • git checkout master
 #
 #   Next Steps (Manual):
@@ -46,8 +54,9 @@
 #   │ 2. Review changes (version bumps, changelog)               │
 #   │ 3. Merge PR                                                 │
 #   │    └─> Triggers GitHub Actions: .github/workflows/publish.yml │
-#   │        • Publishes to npm (company service account)        │
-#   │        • Creates git tags                                  │
+#   │        • Detects version change in lerna.json              │
+#   │        • Creates git tag                          │
+#   │        • Publishes to npm        │
 #   └────────────────────────────────────────────────────────────┘
 #
 
@@ -84,6 +93,11 @@ echo '📝 Analyzing commits and determining version bump...'
 echo '   (using conventional commits since last release)'
 echo ''
 
+# Save current version before running lerna
+CURRENT_VERSION=$(jq -r '.version' lerna.json)
+echo "Current version: $CURRENT_VERSION"
+echo ''
+
 # Run lerna version without git operations
 # This will:
 # - Analyze commits since last tag
@@ -101,7 +115,9 @@ npx lerna version \
 
 if [ $? -ne 0 ]; then
     echo ''
-    echo '❌ Lerna version failed. Cleaning up...'
+    echo '❌ Lerna version command failed.'
+    echo ''
+    echo 'Cleaning up...'
     git checkout master
     git branch -D "$TEMP_BRANCH" 2>/dev/null || true
     exit 1
@@ -109,6 +125,22 @@ fi
 
 # Get the new version
 NEW_VERSION=$(jq -r '.version' lerna.json)
+
+# Check if version actually changed
+if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
+    echo ''
+    echo 'ℹ️  No version bump occurred - nothing to release.'
+    echo ''
+    echo '   No conventional commits found since last release.'
+    echo '   Current version: '$CURRENT_VERSION
+    echo ''
+    echo 'Cleaning up...'
+    git checkout master
+    git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+    echo ''
+    echo '✅ No changes to release at this time.'
+    exit 0
+fi
 
 if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "null" ]; then
     echo ''

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -142,9 +142,13 @@ git push origin "$RELEASE_BRANCH"
 
 if [ $? -ne 0 ]; then
     echo ''
-    echo '❌ Failed to push to GitHub. Please check your permissions.'
+    echo '❌ Failed to push to GitHub.'
     exit 1
 fi
+
+# Switch back to master branch
+echo '🔄 Switching back to master branch...'
+git checkout master
 
 echo ''
 echo '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
@@ -161,9 +165,4 @@ echo '3. Merge the PR to trigger automated publishing'
 echo ''
 echo '⚠️  Publishing to npm will happen automatically when PR is merged!'
 echo '   Git tags will be created automatically during the merge process.'
-echo ''
-
-# Switch back to master branch
-echo '🔄 Switching back to master branch...'
-git checkout master
 echo ''

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -14,7 +14,8 @@
 #        │                                                         │
 #        ├─ 2. SYNC & BRANCH ──────────────────────────────────────┤
 #        │   • git pull origin master                              │
-#        │   • git checkout -b release/pending-TIMESTAMP           │
+#        │   • Check if zcli-release exists on remote (error if found) │
+#        │   • git checkout -b zcli-release                        │
 #        │                                                         │
 #        ├─ 3. INSTALL & VERSION ──────────────────────────────────┤
 #        │   • yarn install --frozen-lockfile                      │
@@ -38,19 +39,18 @@
 #        │     └─ Exit 0 (success, no release needed)             │
 #        │   • If changed: Continue to next step                  │
 #        │                                                          │
-#        ├─ 5. COMMIT & RENAME ────────────────────────────────────┤
+#        ├─ 5. COMMIT ─────────────────────────────────────────────┤
 #        │   • git commit -m "chore(release): publish X.X.X"       │
-#        │   • git branch -m release/X.X.X                           │
 #        │                                                          │
 #        ├─ 6. PUSH TO GITHUB ─────────────────────────────────────┤
-#        │   • git push origin release/X.X.X                       │
+#        │   • git push origin zcli-release                        │
 #        │                                                          │
 #        └─ 7. SWITCH BACK ────────────────────────────────────────┘
 #            • git checkout master
 #
 #   Next Steps (Manual):
 #   ┌────────────────────────────────────────────────────────────┐
-#   │ 1. Create PR: release/X.X.X → master                       │
+#   │ 1. Create PR: zcli-release → master                        │
 #   │ 2. Review changes (version bumps, changelog)               │
 #   │ 3. Merge PR                                                 │
 #   │    └─> Triggers GitHub Actions: .github/workflows/publish.yml │
@@ -80,10 +80,19 @@ fi
 echo '🔄 Pulling latest changes from master...'
 git pull origin master
 
-echo '🌿 Creating temporary release branch...'
-# Create temporary branch - will be renamed after version is determined
-TEMP_BRANCH="release/pending-$(date +%Y%m%d-%H%M%S)"
-git checkout -b "$TEMP_BRANCH"
+# Check if release branch already exists on remote
+RELEASE_BRANCH="zcli-release"
+
+if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+    echo ''
+    echo "❌ Error: Release branch '$RELEASE_BRANCH' already exists on remote."
+    echo ''
+    echo '   Please close/merge the existing release PR first, then delete the branch.'
+    exit 1
+fi
+
+echo "🌿 Creating release branch: $RELEASE_BRANCH"
+git checkout -b "$RELEASE_BRANCH"
 
 echo '📦 Installing dependencies...'
 yarn install --frozen-lockfile
@@ -119,7 +128,7 @@ if [ $? -ne 0 ]; then
     echo ''
     echo 'Cleaning up...'
     git checkout master
-    git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+    git branch -D "$RELEASE_BRANCH" 2>/dev/null || true
     exit 1
 fi
 
@@ -136,7 +145,7 @@ if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
     echo ''
     echo 'Cleaning up...'
     git checkout master
-    git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+    git branch -D "$RELEASE_BRANCH" 2>/dev/null || true
     echo ''
     echo '✅ No changes to release at this time.'
     exit 0
@@ -146,7 +155,7 @@ if [ -z "$NEW_VERSION" ] || [ "$NEW_VERSION" = "null" ]; then
     echo ''
     echo '❌ Could not determine new version. Cleaning up...'
     git checkout master
-    git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+    git branch -D "$RELEASE_BRANCH" 2>/dev/null || true
     exit 1
 fi
 
@@ -156,11 +165,6 @@ echo "✅ Version bumped to: $NEW_VERSION"
 echo '📝 Committing version changes...'
 git add .
 git commit -m "chore(release): publish $NEW_VERSION"
-
-# Rename branch to use the actual version
-RELEASE_BRANCH="release/$NEW_VERSION"
-echo "🔄 Renaming branch to: $RELEASE_BRANCH"
-git branch -m "$RELEASE_BRANCH"
 echo ''
 
 # Get list of changed packages
@@ -191,7 +195,7 @@ echo "📋 Version: $NEW_VERSION"
 echo "🌿 Branch:  $RELEASE_BRANCH"
 echo ''
 echo 'Next steps:'
-echo '1. Open a PR: https://github.com/zendesk/zcli/compare/'$RELEASE_BRANCH'?expand=1'
+echo '1. Open a PR: https://github.com/zendesk/zcli/compare/zcli-release?expand=1'
 echo '2. Review the version bumps and changelog'
 echo '3. Merge the PR to trigger automated publishing'
 echo ''


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

- This PR introduces a new script - `create-release-pr.sh`                                                                               
                                                                                                       
  ### What it does:                                                                                    
  - Automates the release PR creation process using Lerna's conventional commits                
  - Analyzes commit history to determine semantic version bumps (major/minor/patch)                    
  - Updates package versions and generates changelogs automatically                                    
  - Creates and pushes a properly named release branch (`release/X.X.X`)                               
  - Includes comprehensive checks and error handling                                        
                                                                                                       
  ### Workflow:                                                                                        
  1. Developer runs `./scripts/create-release-pr.sh` from master                                       
  2. Script analyzes commits, bumps versions, and pushes release branch                                
  3. Developer creates and reviews PR manually                                                         
  4. On approval and merge, GitHub Actions publishes packages to npm (future implementation - will be part of subsequent PR)                                  
                                                                                                       
  This PR is a part of the wider effort to replace the manual process (running release.sh), have team's oversight via release PRs and to leverage Zendesk service account to publish to npm.

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`cd15797`](https://github.com/zendesk/zcli/pull/331/commits/cd15797a7640f0b831008788fb52fd698fe98428) Chore:npm publish - release PR workflow



### [`00df3c9`](https://github.com/zendesk/zcli/pull/331/commits/00df3c937599a468ba469ea59d82f1a8e0b9c09a) Updated ordering and error message



### [`8dc369e`](https://github.com/zendesk/zcli/pull/331/commits/8dc369ee9deacb3c1000a1f55343ee66e4568129) Removed beta prefix from zcli release version



### [`88abf58`](https://github.com/zendesk/zcli/pull/331/commits/88abf58ec3b47fd6d1c5fa06588cf47ace252b73) Updated script to remove beta/pre-release version prefixes. The script will release stable versions



### [`6ad7be1`](https://github.com/zendesk/zcli/pull/331/commits/6ad7be1cd299d7034069a305058e0e99c25df1c5) Early exit when no conventional commits are found



### [`bbde843`](https://github.com/zendesk/zcli/pull/331/commits/bbde8433186492d834ebc545b2cd015bf1ce8bb8) feat: adding list command to connectors zcli



### [`3979008`](https://github.com/zendesk/zcli/pull/331/commits/397900881d6e2253ebb44082dce338d0f7a1b837) fix: update response log based on review

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

### [`0cfa279`](https://github.com/zendesk/zcli/pull/331/commits/0cfa27935be5ea77b26c56ec2019a761c17b7b1c) fix: removng localestriing conversion

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

### [`2b3b397`](https://github.com/zendesk/zcli/pull/331/commits/2b3b397654a323df7eb4649e0e0507a97e786d02) fix: apply suggestions from code review

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

### [`95035ec`](https://github.com/zendesk/zcli/pull/331/commits/95035ec5c1cbfdb5c33e85c43feed1c1cef33f25) fix: adding tests for list command



### [`d21dab8`](https://github.com/zendesk/zcli/pull/331/commits/d21dab8f725e96c487468dc457cf31d86381c1f8) fix: fixing failing test for list



### [`2339bbd`](https://github.com/zendesk/zcli/pull/331/commits/2339bbdc3fe24791a5050ddaf77fd2a9c5c1d6e6) fix: adding condition for spinner and exit 1

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

### [`1219345`](https://github.com/zendesk/zcli/pull/331/commits/12193450e648b050c6de9b4e51cb27fd40b1f725) fix: refactoring non 200 response case

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

### [`2936abe`](https://github.com/zendesk/zcli/pull/331/commits/2936abe65ddbe2fd74d21e11d56e6da088d683c8) fix: modifying endpoint for list



### [`4a9851f`](https://github.com/zendesk/zcli/pull/331/commits/4a9851f2af5a6c5291d9952cd4243ef0576f19ad) fix: lint and test fixes



### [`a86d4ae`](https://github.com/zendesk/zcli/pull/331/commits/a86d4ae69cc79b8bb212ec434e060cba9cbca3a6) fix: remove connector nice id column



### [`c435d59`](https://github.com/zendesk/zcli/pull/331/commits/c435d59b3c25625b5a095cd056a66b56f50b4c54) feat: Add automated release PR workflow with generic branch name

- Update release script to use 'zcli-release' branch instead of version-based naming
- Add remote branch existence check to prevent duplicate releases
- Create GitHub Actions workflow for manual release PR creation
- Remove local branch check as it's unnecessary in GHA environment

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- === GH HISTORY FENCE === -->

## Detail
https://zendesk.atlassian.net/browse/APPS-8078
<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
