### PR TITLE
feat: adding list command to connectors zcli

### DIFF
--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -120,11 +120,6 @@ export default class List extends Command {
     this.log(chalk.green(`\nFound ${connectors.length} connector(s):\n`))
 
     CliUx.ux.table(connectors, {
-      connector_nice_id: {
-        header: 'ID',
-        minWidth: 25,
-        get: (row: ConnectorListItem) => row.connector_nice_id || row.connector_name
-      },
       title: {
         header: 'Title',
         minWidth: 30,
@@ -132,7 +127,8 @@ export default class List extends Command {
       },
       connector_name: {
         header: 'Connector Name',
-        minWidth: 25
+        minWidth: 25,
+        get: (row: ConnectorListItem) => row.connector_nice_id || row.connector_name
       },
       version: {
         header: 'Version',

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -43,7 +43,7 @@ export default class List extends Command {
     const { flags } = await this.parse(List)
 
     if (flags.verbose) {
-      this.log(chalk.cyan('Verbose mode enabled'))
+      this.logVerbose('Verbose mode enabled', flags.json)
     }
 
     const spinner = ora('Fetching connectors...').start()
@@ -56,8 +56,8 @@ export default class List extends Command {
       spinner.stop()
 
       if (flags.verbose) {
-        this.log(chalk.cyan(`API response status: ${response.status}`))
-        this.log(chalk.cyan(`Response data: ${JSON.stringify(response.data, null, 2)}`))
+        this.logVerbose(`API response status: ${response.status}`, flags.json)
+        this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`, flags.json)
       }
 
       const data = response.data as ListConnectorsResponse
@@ -76,28 +76,53 @@ export default class List extends Command {
 
       // Non-JSON output mode
       if (response.status !== 200) {
-        this.log(chalk.red(`API returned non-200 status: ${response.status}`))
-        this.log(chalk.yellow('Response data:'), JSON.stringify(response.data, null, 2))
+        const errorMsg = `API returned non-200 status: ${response.status}`
+        const responseData = JSON.stringify(response.data, null, 2)
+
+        if (flags.json) {
+          // In JSON mode, write error details to stderr
+          process.stderr.write(chalk.red(errorMsg) + '\n')
+          process.stderr.write(chalk.yellow('Response data: ') + responseData + '\n')
+        } else {
+          this.log(chalk.red(errorMsg))
+          this.log(chalk.yellow('Response data:'), responseData)
+        }
         return
       }
 
       if (!data.connectors || data.connectors.length === 0) {
-        this.log(chalk.yellow('No connectors found'))
+        if (flags.json) {
+          this.log(JSON.stringify([], null, 2))
+        } else {
+          this.log(chalk.yellow('No connectors found'))
+        }
         return
       }
 
       this.displayTable(data.connectors)
     } catch (error) {
-      spinner.fail(chalk.red('Failed to fetch connectors'))
+      if (!flags.json) {
+        spinner.fail(chalk.red('Failed to fetch connectors'))
+      }
 
       const errorMessage = (error instanceof Error) ? error.message : String(error)
 
       if (flags.verbose) {
-        this.log('\n' + chalk.red('Error Details:'))
-        this.log(errorMessage)
+        this.logVerbose('\nError Details:', flags.json, 'red')
+        this.logVerbose(errorMessage, flags.json)
       }
 
       this.error(errorMessage, { exit: 1 })
+    }
+  }
+
+  private logVerbose (message: string, isJsonMode: boolean, color?: 'cyan' | 'red'): void {
+    const coloredMessage = color ? chalk[color](message) : chalk.cyan(message)
+    if (isJsonMode) {
+      // Write to stderr to avoid corrupting JSON output on stdout
+      process.stderr.write(coloredMessage + '\n')
+    } else {
+      this.log(coloredMessage)
     }
   }
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -1,0 +1,137 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import * as chalk from 'chalk'
+import * as ora from 'ora'
+import { request } from '@zendesk/zcli-core'
+
+interface ConnectorListItem {
+  connector_name: string
+  connector_nice_id: string | null
+  title: string | null
+  version: string
+  description: string | null
+  created_at: string
+  updated_at: string
+  [key: string]: string | null
+}
+
+interface ListConnectorsResponse {
+  connectors: ConnectorListItem[]
+}
+
+export default class List extends Command {
+  static description = 'list all private connectors for the current account'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --json'
+  ]
+
+  static flags = {
+    help: Flags.help({ char: 'h' }),
+    json: Flags.boolean({
+      description: 'output in JSON format',
+      default: false
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'verbose output',
+      default: false
+    })
+  }
+
+  async run (): Promise<void> {
+    const { flags } = await this.parse(List)
+
+    if (flags.verbose) {
+      this.log(chalk.cyan('Verbose mode enabled'))
+    }
+
+    const spinner = ora('Fetching connectors...').start()
+
+    try {
+      const response = await request.requestAPI('/flowstate/connectors/private/list', {
+        method: 'GET'
+      })
+
+      spinner.stop()
+
+      if (flags.verbose) {
+        this.log(chalk.cyan(`API response status: ${response.status}`))
+        this.log(chalk.cyan(`Response data: ${JSON.stringify(response.data, null, 2)}`))
+      }
+
+      // Check for non-200 status
+      if (response.status !== 200) {
+        this.log(chalk.red(`API returned non-200 status: ${response.status}`))
+        this.log(chalk.yellow('Response data:'), JSON.stringify(response.data, null, 2))
+        return
+      }
+
+      const data = response.data as ListConnectorsResponse
+
+      if (!data.connectors || data.connectors.length === 0) {
+        this.log(chalk.yellow('No connectors found'))
+        return
+      }
+
+      if (flags.json) {
+        this.log(JSON.stringify(data.connectors, null, 2))
+      } else {
+        this.displayTable(data.connectors)
+      }
+    } catch (error) {
+      spinner.fail(chalk.red('Failed to fetch connectors'))
+
+      const errorMessage = (error instanceof Error) ? error.message : String(error)
+
+      if (flags.verbose) {
+        this.log('\n' + chalk.red('Error Details:'))
+        this.log(errorMessage)
+      }
+
+      this.error(errorMessage, { exit: 1 })
+    }
+  }
+
+  private displayTable (connectors: ConnectorListItem[]): void {
+    this.log(chalk.green(`\nFound ${connectors.length} connector(s):\n`))
+
+    CliUx.ux.table(connectors, {
+      connector_nice_id: {
+        header: 'ID',
+        minWidth: 25,
+        get: (row: ConnectorListItem) => row.connector_nice_id || row.connector_name
+      },
+      title: {
+        header: 'Title',
+        minWidth: 30,
+        get: (row: ConnectorListItem) => row.title || row.connector_name
+      },
+      connector_name: {
+        header: 'Connector Name',
+        minWidth: 25
+      },
+      version: {
+        header: 'Version',
+        minWidth: 10
+      },
+      description: {
+        header: 'Description',
+        minWidth: 35,
+        get: (row: ConnectorListItem) => row.description || '-'
+      },
+      created_at: {
+        header: 'Created',
+        minWidth: 20,
+        get: (row: ConnectorListItem) => new Date(row.created_at).toLocaleString()
+      },
+      updated_at: {
+        header: 'Updated',
+        minWidth: 20,
+        get: (row: ConnectorListItem) => new Date(row.updated_at).toLocaleString()
+      }
+    }, {
+      printLine: this.log.bind(this)
+    })
+  }
+}

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -68,6 +68,12 @@ export default class List extends Command {
           // Route error to stderr and exit via outer catch; no human-readable output on stdout
           throw new Error(`API returned non-200 status: ${response.status}`)
         }
+
+        const connectors = data.connectors ?? []
+        this.log(JSON.stringify(connectors, null, 2))
+        return
+      }
+
       // Non-JSON output mode: handle non-200 responses with human-readable output
       if (response.status !== 200) {
         const errorMsg = `API returned non-200 status: ${response.status}`
@@ -86,7 +92,7 @@ export default class List extends Command {
       this.displayTable(data.connectors)
     } catch (error) {
       if (!flags.json) {
-        spinner.fail(chalk.red('Failed to fetch connectors'))
+        spinner?.fail(chalk.red('Failed to fetch connectors'))
       }
 
       const errorMessage = (error instanceof Error) ? error.message : String(error)

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -46,14 +46,14 @@ export default class List extends Command {
       this.logVerbose('Verbose mode enabled', flags.json)
     }
 
-    const spinner = ora('Fetching connectors...').start()
+    const spinner = flags.json ? null : ora('Fetching connectors...').start()
 
     try {
       const response = await request.requestAPI('/flowstate/connectors/private/list', {
         method: 'GET'
       })
 
-      spinner.stop()
+      spinner?.stop()
 
       if (flags.verbose) {
         this.logVerbose(`API response status: ${response.status}`, flags.json)
@@ -76,18 +76,12 @@ export default class List extends Command {
 
       // Non-JSON output mode
       if (response.status !== 200) {
-        const errorMsg = `API returned non-200 status: ${response.status}`
-        const responseData = JSON.stringify(response.data, null, 2)
+        const baseErrorMsg = `API returned non-200 status: ${response.status}`
+        const verboseSuffix = flags.verbose
+          ? '\n' + chalk.yellow('Response data: ') + JSON.stringify(response.data, null, 2)
+          : ''
 
-        if (flags.json) {
-          // In JSON mode, write error details to stderr
-          process.stderr.write(chalk.red(errorMsg) + '\n')
-          process.stderr.write(chalk.yellow('Response data: ') + responseData + '\n')
-        } else {
-          this.log(chalk.red(errorMsg))
-          this.log(chalk.yellow('Response data:'), responseData)
-        }
-        return
+        this.error(baseErrorMsg + verboseSuffix, { exit: 1 })
       }
 
       if (!data.connectors || data.connectors.length === 0) {

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -131,12 +131,12 @@ export default class List extends Command {
       created_at: {
         header: 'Created',
         minWidth: 20,
-        get: (row: ConnectorListItem) => new Date(row.created_at).toLocaleString()
+        get: (row: ConnectorListItem) => row.created_at
       },
       updated_at: {
         header: 'Updated',
         minWidth: 20,
-        get: (row: ConnectorListItem) => new Date(row.updated_at).toLocaleString()
+        get: (row: ConnectorListItem) => row.updated_at
       }
     }, {
       printLine: this.log.bind(this)

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -49,7 +49,7 @@ export default class List extends Command {
     const spinner = flags.json ? null : ora('Fetching connectors...').start()
 
     try {
-      const response = await request.requestAPI('/flowstate/connectors/private/list', {
+      const response = await request.requestAPI('/flowstate/connectors/private', {
         method: 'GET'
       })
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -68,28 +68,18 @@ export default class List extends Command {
           // Route error to stderr and exit via outer catch; no human-readable output on stdout
           throw new Error(`API returned non-200 status: ${response.status}`)
         }
+      // Non-JSON output mode: handle non-200 responses with human-readable output
+      if (response.status !== 200) {
+        const errorMsg = `API returned non-200 status: ${response.status}`
+        const responseData = JSON.stringify(response.data, null, 2)
 
-        const connectors = data.connectors ?? []
-        this.log(JSON.stringify(connectors, null, 2))
+        this.log(chalk.red(errorMsg))
+        this.log(chalk.yellow('Response data:'), responseData)
         return
       }
 
-      // Non-JSON output mode
-      if (response.status !== 200) {
-        const baseErrorMsg = `API returned non-200 status: ${response.status}`
-        const verboseSuffix = flags.verbose
-          ? '\n' + chalk.yellow('Response data: ') + JSON.stringify(response.data, null, 2)
-          : ''
-
-        this.error(baseErrorMsg + verboseSuffix, { exit: 1 })
-      }
-
       if (!data.connectors || data.connectors.length === 0) {
-        if (flags.json) {
-          this.log(JSON.stringify([], null, 2))
-        } else {
-          this.log(chalk.yellow('No connectors found'))
-        }
+        this.log(chalk.yellow('No connectors found'))
         return
       }
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -15,7 +15,7 @@ interface ConnectorListItem {
 }
 
 interface ListConnectorsResponse {
-  connectors: ConnectorListItem[]
+  connectors?: ConnectorListItem[]
 }
 
 export default class List extends Command {
@@ -65,8 +65,8 @@ export default class List extends Command {
       // JSON output mode: always emit JSON to stdout
       if (flags.json) {
         if (response.status !== 200) {
-          // Route error to stderr and exit; no human-readable output on stdout
-          this.error(`API returned non-200 status: ${response.status}`, { exit: 1 })
+          // Route error to stderr and exit via outer catch; no human-readable output on stdout
+          throw new Error(`API returned non-200 status: ${response.status}`)
         }
 
         const connectors = data.connectors ?? []

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -60,25 +60,33 @@ export default class List extends Command {
         this.log(chalk.cyan(`Response data: ${JSON.stringify(response.data, null, 2)}`))
       }
 
-      // Check for non-200 status
+      const data = response.data as ListConnectorsResponse
+
+      // JSON output mode: always emit JSON to stdout
+      if (flags.json) {
+        if (response.status !== 200) {
+          // Route error to stderr and exit; no human-readable output on stdout
+          this.error(`API returned non-200 status: ${response.status}`, { exit: 1 })
+        }
+
+        const connectors = data.connectors ?? []
+        this.log(JSON.stringify(connectors, null, 2))
+        return
+      }
+
+      // Non-JSON output mode
       if (response.status !== 200) {
         this.log(chalk.red(`API returned non-200 status: ${response.status}`))
         this.log(chalk.yellow('Response data:'), JSON.stringify(response.data, null, 2))
         return
       }
 
-      const data = response.data as ListConnectorsResponse
-
       if (!data.connectors || data.connectors.length === 0) {
         this.log(chalk.yellow('No connectors found'))
         return
       }
 
-      if (flags.json) {
-        this.log(JSON.stringify(data.connectors, null, 2))
-      } else {
-        this.displayTable(data.connectors)
-      }
+      this.displayTable(data.connectors)
     } catch (error) {
       spinner.fail(chalk.red('Failed to fetch connectors'))
 

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -13,6 +13,7 @@ describe('list command', () => {
   let logStub: sinon.SinonStub
   let requestAPIStub: sinon.SinonStub
   let stderrWriteStub: sinon.SinonStub
+  let parseStub: sinon.SinonStub
 
   const mockConnectorData = [
     {
@@ -67,7 +68,7 @@ describe('list command', () => {
 
   describe('successful list operations', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,
@@ -126,7 +127,7 @@ describe('list command', () => {
 
   describe('JSON output mode', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: false,
@@ -184,7 +185,7 @@ describe('list command', () => {
 
   describe('verbose mode', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: true,
@@ -206,7 +207,8 @@ describe('list command', () => {
     })
 
     it('should log verbose messages to stderr in JSON mode', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: true,
@@ -235,7 +237,7 @@ describe('list command', () => {
 
   describe('error handling - non-200 responses', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,
@@ -267,7 +269,8 @@ describe('list command', () => {
     })
 
     it('should route non-200 errors to stderr in JSON mode', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: false,
@@ -275,16 +278,28 @@ describe('list command', () => {
         }
       })
 
+      const errorStub = sinon.stub(listCommand, 'error').callsFake((message: any) => {
+        const err = new Error(String(message))
+        throw err
+      })
+
       requestAPIStub.resolves({
         status: 404,
         data: { error: 'Not Found' }
       })
 
-      await listCommand.run()
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected to throw
+      }
 
-      // Error should go to stderr in JSON mode
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 404/))
-      expect(logStub).to.not.have.been.called
+      // Error should go through this.error() in JSON mode
+      expect(errorStub).to.have.been.calledWith(
+        'API returned non-200 status: 404',
+        sinon.match({ exit: 1 })
+      )
     })
   })
 
@@ -293,7 +308,7 @@ describe('list command', () => {
     let caughtError: Error | undefined
 
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,
@@ -349,7 +364,8 @@ describe('list command', () => {
     })
 
     it('should log verbose error details when verbose flag is set', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: true,
@@ -372,7 +388,8 @@ describe('list command', () => {
     })
 
     it('should route verbose error details to stderr in JSON mode', async () => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub.restore()
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: true,
           verbose: true,
@@ -398,7 +415,7 @@ describe('list command', () => {
 
   describe('API response edge cases', () => {
     beforeEach(() => {
-      sinon.stub(listCommand, 'parse' as any).resolves({
+      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
           json: false,
           verbose: false,

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -1,0 +1,443 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect, use } from 'chai'
+import * as sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import ListCommand from '../../src/commands/connectors/list'
+import { request } from '@zendesk/zcli-core'
+
+use(sinonChai)
+
+describe('list command', () => {
+  let listCommand: ListCommand
+  let logStub: sinon.SinonStub
+  let requestAPIStub: sinon.SinonStub
+  let stderrWriteStub: sinon.SinonStub
+
+  const mockConnectorData = [
+    {
+      connector_name: 'test-connector-1',
+      connector_nice_id: 'nice-id-1',
+      title: 'Test Connector 1',
+      version: '1.0.0',
+      description: 'A test connector',
+      created_at: '2026-03-01T00:00:00Z',
+      updated_at: '2026-03-15T00:00:00Z'
+    },
+    {
+      connector_name: 'test-connector-2',
+      connector_nice_id: 'nice-id-2',
+      title: 'Test Connector 2',
+      version: '2.1.0',
+      description: null,
+      created_at: '2026-03-10T00:00:00Z',
+      updated_at: '2026-03-20T00:00:00Z'
+    }
+  ]
+
+  beforeEach(() => {
+    listCommand = new ListCommand([], {} as any)
+    logStub = sinon.stub(listCommand, 'log')
+    requestAPIStub = sinon.stub(request, 'requestAPI')
+    stderrWriteStub = sinon.stub(process.stderr, 'write')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('command flags', () => {
+    it('should have help flag', () => {
+      expect(ListCommand.flags.help).to.exist
+    })
+
+    it('should have json flag', () => {
+      expect(ListCommand.flags.json).to.exist
+      expect(ListCommand.flags.json.type).to.equal('boolean')
+      expect(ListCommand.flags.json.default).to.equal(false)
+    })
+
+    it('should have verbose flag with char v', () => {
+      expect(ListCommand.flags.verbose).to.exist
+      expect(ListCommand.flags.verbose.char).to.equal('v')
+      expect(ListCommand.flags.verbose.type).to.equal('boolean')
+      expect(ListCommand.flags.verbose.default).to.equal(false)
+    })
+  })
+
+  describe('successful list operations', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should successfully list connectors in table format', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      expect(requestAPIStub).to.have.been.calledWith('/flowstate/connectors/private/list', {
+        method: 'GET'
+      })
+      expect(logStub).to.have.been.calledWith(sinon.match(/Found 2 connector/))
+    })
+
+    it('should display empty list message when no connectors exist', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: [] }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+
+    it('should handle connectors with null values gracefully', async () => {
+      const connectorWithNulls = [{
+        connector_name: 'test-connector',
+        connector_nice_id: null,
+        title: null,
+        version: '1.0.0',
+        description: null,
+        created_at: '2026-03-01T00:00:00Z',
+        updated_at: '2026-03-15T00:00:00Z'
+      }]
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: connectorWithNulls }
+      })
+
+      await listCommand.run()
+
+      expect(requestAPIStub).to.have.been.called
+      expect(logStub).to.have.been.calledWith(sinon.match(/Found 1 connector/))
+    })
+  })
+
+  describe('JSON output mode', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should output JSON format when --json flag is set', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      const parsedOutput = JSON.parse(outputArg)
+
+      expect(parsedOutput).to.be.an('array')
+      expect(parsedOutput).to.have.lengthOf(2)
+      expect(parsedOutput[0]).to.have.property('connector_name', 'test-connector-1')
+      expect(parsedOutput[1]).to.have.property('connector_name', 'test-connector-2')
+    })
+
+    it('should output empty JSON array when no connectors exist', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: [] }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      const parsedOutput = JSON.parse(outputArg)
+
+      expect(parsedOutput).to.be.an('array')
+      expect(parsedOutput).to.have.lengthOf(0)
+    })
+
+    it('should not output spinner in JSON mode', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      // In JSON mode, no spinner-related logs should be on stdout
+      expect(logStub).to.have.been.calledOnce
+    })
+  })
+
+  describe('verbose mode', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: true,
+          help: false
+        }
+      })
+    })
+
+    it('should log verbose messages to stdout in normal mode', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+    })
+
+    it('should log verbose messages to stderr in JSON mode', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: true,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: mockConnectorData }
+      })
+
+      await listCommand.run()
+
+      // Verbose logs should go to stderr, not stdout
+      expect(stderrWriteStub).to.have.been.called
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+
+      // Only JSON output should be on stdout
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      expect(() => JSON.parse(outputArg)).to.not.throw()
+    })
+  })
+
+  describe('error handling - non-200 responses', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should handle 403 Forbidden response', async () => {
+      requestAPIStub.resolves({
+        status: 403,
+        data: { error: 'Forbidden' }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 403/))
+    })
+
+    it('should handle 500 Internal Server Error response', async () => {
+      requestAPIStub.resolves({
+        status: 500,
+        data: { error: 'Internal Server Error' }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 500/))
+    })
+
+    it('should route non-200 errors to stderr in JSON mode', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: false,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 404,
+        data: { error: 'Not Found' }
+      })
+
+      await listCommand.run()
+
+      // Error should go to stderr in JSON mode
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 404/))
+      expect(logStub).to.not.have.been.called
+    })
+  })
+
+  describe('error handling - API failures', () => {
+    let errorStub: sinon.SinonStub
+    let caughtError: Error | undefined
+
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+
+      errorStub = sinon.stub(listCommand, 'error').callsFake((message: any, options: any) => {
+        const err = new Error(String(message))
+        ;(err as any).options = options
+        throw err
+      })
+    })
+
+    afterEach(() => {
+      caughtError = undefined
+    })
+
+    it('should handle network errors', async () => {
+      const networkError = new Error('Network request failed: ECONNREFUSED')
+      requestAPIStub.rejects(networkError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(caughtError).to.exist
+      expect(errorStub).to.have.been.calledWith(
+        'Network request failed: ECONNREFUSED',
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should handle authentication errors', async () => {
+      const authError = new Error('Authentication failed: Invalid credentials')
+      requestAPIStub.rejects(authError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(caughtError).to.exist
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Authentication failed/),
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should log verbose error details when verbose flag is set', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: true,
+          help: false
+        }
+      })
+
+      const detailedError = new Error('Detailed error message')
+      requestAPIStub.rejects(detailedError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Error Details:/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/Detailed error message/))
+    })
+
+    it('should route verbose error details to stderr in JSON mode', async () => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: true,
+          verbose: true,
+          help: false
+        }
+      })
+
+      const detailedError = new Error('Error in JSON mode')
+      requestAPIStub.rejects(detailedError)
+
+      try {
+        await listCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      // Verbose error details should go to stderr
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error Details:/))
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error in JSON mode/))
+    })
+  })
+
+  describe('API response edge cases', () => {
+    beforeEach(() => {
+      sinon.stub(listCommand, 'parse' as any).resolves({
+        flags: {
+          json: false,
+          verbose: false,
+          help: false
+        }
+      })
+    })
+
+    it('should handle null connectors array', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { connectors: null }
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+
+    it('should handle undefined connectors array', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+
+    it('should handle malformed response data', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: 'not an object'
+      })
+
+      await listCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/No connectors found/))
+    })
+  })
+})

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -85,7 +85,7 @@ describe('list command', () => {
 
       await listCommand.run()
 
-      expect(requestAPIStub).to.have.been.calledWith('/flowstate/connectors/private/list', {
+      expect(requestAPIStub).to.have.been.calledWith('/flowstate/connectors/private', {
         method: 'GET'
       })
       expect(logStub).to.have.been.calledWith(sinon.match(/Found 2 connector/))


### PR DESCRIPTION
# Add list command for private connectors


Implements the `connectors:list` command in ZCLI to retrieve and display all private connectors for the authenticated account. This command provides both human-readable table output and machine-readable JSON output with verbose logging support.

## JIRA 

[VEG-3620](https://zendesk.atlassian.net/browse/VEG-3620)


### Command Flags
- **`--json`** - Output results in JSON format for programmatic consumption
- **`--verbose, -v`** - Enable detailed logging including API status and response data


##  Usage Examples

```bash
# List all connectors in table format
zcli connectors:list

# Output as JSON
zcli connectors:list --json

# Show verbose API details
zcli connectors:list --verbose

```

##  Manual Testing Performed

### Test Scenarios Validated

####  Happy Path
- [x] Successfully lists multiple connectors
- [x] Table displays with correct columns and formatting
- [x] Spinner shows and stops correctly

#### JSON Output
- [x] Clean JSON array output
- [x] No spinner or extra text in JSON mode

#### Verbose Mode
- [x] Shows "Verbose mode enabled" message
- [x] Logs API response status (200)
- [x] Displays full response data
- [x] In JSON mode, verbose logs go to stderr

#### Empty Results
- [x] Shows "No connectors found" message
- [x] Returns empty JSON array in JSON mode

####  Error Scenarios
- [x] 403 Forbidden: Shows appropriate error
- [x] 500 Server Error: Displays error message
- [x] Network failures: Shows connection error
- [x] All errors properly route to stderr in JSON mode

## API Integration

### Endpoint
- **URL**: `GET /flowstate/connectors/private`
- **Method**: GET
- **Authentication**: Required (uses standard ZCLI auth)
- **Authorization**: Admin access required


## Output example

### Success Flow
```
$ zcli connectors:list
⠋ Fetching connectors...

Found 3 connector(s):

ID              Title                   Connector Name        Version  Description
sf-conn-001     Salesforce Connector    salesforce-connector  1.0.0    Connect to Salesforce
slack-conn-002  Slack Integration       slack-connector       2.1.0    Send notifications
jira-conn-003   Jira Connector          jira-connector        1.5.2    -
```

### JSON Output Flow
```
$ zcli connectors:list --json
[
  {
    "connector_name": "salesforce-connector",
    "connector_nice_id": "sf-conn-001",
    "title": "Salesforce Connector",
    "version": "1.0.0",
    ...
  }
]
```

### Error Flow
```
$ zcli connectors:list
⠹ Fetching connectors...
✖ Failed to fetch connectors
Error: API returned non-200 status: 403
```

---

**Testing Commands**
```bash

# Manual test
yarn dev connectors:list
yarn dev connectors:list --json
yarn dev connectors:list --verbose
```


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->


[VEG-3620]: https://zendesk.atlassian.net/browse/VEG-3620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
