### PR TITLE
feat: adding zcli delete command

### DIFF
--- a/packages/zcli-connectors/src/commands/connectors/delete.ts
+++ b/packages/zcli-connectors/src/commands/connectors/delete.ts
@@ -3,6 +3,8 @@ import * as chalk from 'chalk'
 import * as ora from 'ora'
 import { request } from '@zendesk/zcli-core'
 
+export const { ux } = CliUx
+
 export default class Delete extends Command {
   static description = 'delete a private connector from your account'
 
@@ -39,7 +41,7 @@ export default class Delete extends Command {
 
     let connectorName = args.connector
     if (!connectorName) {
-      connectorName = await CliUx.ux.prompt('Connector name')
+      connectorName = await ux.prompt('Connector name')
     }
 
     connectorName = connectorName.trim()
@@ -55,9 +57,9 @@ export default class Delete extends Command {
 
     // Confirmation prompt (skip if --force)
     if (!flags.force) {
-      const confirmation = (await CliUx.ux.prompt(
+      const confirmation = await ux.prompt(
         `Are you sure you want to delete connector '${connectorName}'? Type the connector name to confirm`
-      )).trim()
+      )
 
       if (confirmation !== connectorName) {
         this.log(chalk.yellow('Deletion cancelled'))
@@ -65,7 +67,7 @@ export default class Delete extends Command {
       }
     }
 
-    const spinner = ora('Deleting connector...').start()
+    const spinner = (ora as any)('Deleting connector...').start()
 
     try {
       const response = await request.requestAPI(
@@ -82,30 +84,25 @@ export default class Delete extends Command {
         }
       }
 
-      // Handle success
+      // Handle response
       if (response.status === 200 || response.status === 204) {
         this.log(chalk.green(`✓ Connector '${connectorName}' deleted successfully`))
       } else {
-        // Non-2xx response - construct error message
-        const serializedResponseData = JSON.stringify(response.data)
-        const errorDetails =
-          response.data?.message ||
-          response.data?.error ||
-          serializedResponseData ||
-          'No additional error details provided'
-        throw new Error(`Failed to delete connector: HTTP ${response.status} - ${errorDetails}`)
+        // Handle error response
+        spinner?.stop()
+        const errorDetails = response.data?.message || response.data?.error || 'Unknown error'
+        const errorMessage = `Failed to delete connector: HTTP ${response.status} - ${errorDetails}`
+        if (flags.verbose) {
+          this.logVerbose('\nError Details:', 'red')
+          this.logVerbose(errorMessage, 'red')
+        }
+        this.error(errorMessage, { exit: 1 })
       }
     } catch (error) {
+      // Handle network errors and other exceptions
       spinner?.fail(chalk.red('Failed to delete connector'))
 
-      let errorMessage = (error instanceof Error) ? error.message : String(error)
-
-      // Provide helpful error messages for common cases
-      if (errorMessage.includes('404')) {
-        errorMessage = `Connector '${connectorName}' not found. Use 'zcli connectors:list' to see available connectors.`
-      } else if (errorMessage.includes('403')) {
-        errorMessage = 'Permission denied. You don\'t have access to delete this connector.'
-      }
+      const errorMessage = (error instanceof Error) ? error.message : String(error)
 
       if (flags.verbose) {
         this.logVerbose('\nError Details:', 'red')

--- a/packages/zcli-connectors/src/commands/connectors/delete.ts
+++ b/packages/zcli-connectors/src/commands/connectors/delete.ts
@@ -9,16 +9,11 @@ export default class Delete extends Command {
   static examples = [
     '<%= config.bin %> <%= command.id %> my-connector',
     '<%= config.bin %> <%= command.id %>',
-    '<%= config.bin %> <%= command.id %> my-connector --force',
-    '<%= config.bin %> <%= command.id %> --json'
+    '<%= config.bin %> <%= command.id %> my-connector --force'
   ]
 
   static flags = {
     help: Flags.help({ char: 'h' }),
-    json: Flags.boolean({
-      description: 'output in JSON format',
-      default: false
-    }),
     verbose: Flags.boolean({
       char: 'v',
       description: 'verbose output',
@@ -54,12 +49,12 @@ export default class Delete extends Command {
     }
 
     if (flags.verbose) {
-      this.logVerbose('Verbose mode enabled', flags.json)
-      this.logVerbose(`Connector name: ${connectorName}`, flags.json)
+      this.logVerbose('Verbose mode enabled')
+      this.logVerbose(`Connector name: ${connectorName}`)
     }
 
-    // Confirmation prompt (skip if --force or --json)
-    if (!flags.force && !flags.json) {
+    // Confirmation prompt (skip if --force)
+    if (!flags.force) {
       const confirmation = await CliUx.ux.prompt(
         `Are you sure you want to delete connector '${connectorName}'? Type the connector name to confirm`
       )
@@ -70,7 +65,7 @@ export default class Delete extends Command {
       }
     }
 
-    const spinner = flags.json ? null : ora('Deleting connector...').start()
+    const spinner = ora('Deleting connector...').start()
 
     try {
       const response = await request.requestAPI(
@@ -81,31 +76,22 @@ export default class Delete extends Command {
       spinner?.stop()
 
       if (flags.verbose) {
-        this.logVerbose(`API response status: ${response.status}`, flags.json)
+        this.logVerbose(`API response status: ${response.status}`)
         if (response.data) {
-          this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`, flags.json)
+          this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`)
         }
       }
 
       // Handle success
       if (response.status === 200 || response.status === 204) {
-        if (flags.json) {
-          this.log(JSON.stringify({
-            connectorName,
-            status: 'deleted'
-          }, null, 2))
-        } else {
-          this.log(chalk.green(`✓ Connector '${connectorName}' deleted successfully`))
-        }
+        this.log(chalk.green(`✓ Connector '${connectorName}' deleted successfully`))
       } else {
         // Non-2xx response - construct error message
         const errorDetails = response.data?.message || response.data?.error || JSON.stringify(response.data)
         throw new Error(`Failed to delete connector: HTTP ${response.status} - ${errorDetails}`)
       }
     } catch (error) {
-      if (!flags.json) {
-        spinner?.fail(chalk.red('Failed to delete connector'))
-      }
+      spinner?.fail(chalk.red('Failed to delete connector'))
 
       let errorMessage = (error instanceof Error) ? error.message : String(error)
 
@@ -117,21 +103,16 @@ export default class Delete extends Command {
       }
 
       if (flags.verbose) {
-        this.logVerbose('\nError Details:', flags.json, 'red')
-        this.logVerbose(errorMessage, flags.json, 'red')
+        this.logVerbose('\nError Details:', 'red')
+        this.logVerbose(errorMessage, 'red')
       }
 
       this.error(errorMessage, { exit: 1 })
     }
   }
 
-  private logVerbose (message: string, isJsonMode: boolean, color?: 'cyan' | 'red'): void {
+  private logVerbose (message: string, color?: 'cyan' | 'red'): void {
     const coloredMessage = color ? chalk[color](message) : chalk.cyan(message)
-    if (isJsonMode) {
-      // Write to stderr to avoid corrupting JSON output on stdout
-      process.stderr.write(coloredMessage + '\n')
-    } else {
-      this.log(coloredMessage)
-    }
+    this.log(coloredMessage)
   }
 }

--- a/packages/zcli-connectors/src/commands/connectors/delete.ts
+++ b/packages/zcli-connectors/src/commands/connectors/delete.ts
@@ -55,9 +55,9 @@ export default class Delete extends Command {
 
     // Confirmation prompt (skip if --force)
     if (!flags.force) {
-      const confirmation = await CliUx.ux.prompt(
+      const confirmation = (await CliUx.ux.prompt(
         `Are you sure you want to delete connector '${connectorName}'? Type the connector name to confirm`
-      )
+      )).trim()
 
       if (confirmation !== connectorName) {
         this.log(chalk.yellow('Deletion cancelled'))
@@ -87,7 +87,12 @@ export default class Delete extends Command {
         this.log(chalk.green(`✓ Connector '${connectorName}' deleted successfully`))
       } else {
         // Non-2xx response - construct error message
-        const errorDetails = response.data?.message || response.data?.error || JSON.stringify(response.data)
+        const serializedResponseData = JSON.stringify(response.data)
+        const errorDetails =
+          response.data?.message ||
+          response.data?.error ||
+          serializedResponseData ||
+          'No additional error details provided'
         throw new Error(`Failed to delete connector: HTTP ${response.status} - ${errorDetails}`)
       }
     } catch (error) {

--- a/packages/zcli-connectors/src/commands/connectors/delete.ts
+++ b/packages/zcli-connectors/src/commands/connectors/delete.ts
@@ -1,0 +1,137 @@
+import { Command, Flags, CliUx } from '@oclif/core'
+import * as chalk from 'chalk'
+import * as ora from 'ora'
+import { request } from '@zendesk/zcli-core'
+
+export default class Delete extends Command {
+  static description = 'delete a private connector from your account'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-connector',
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> my-connector --force',
+    '<%= config.bin %> <%= command.id %> --json'
+  ]
+
+  static flags = {
+    help: Flags.help({ char: 'h' }),
+    json: Flags.boolean({
+      description: 'output in JSON format',
+      default: false
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'verbose output',
+      default: false
+    }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'skip confirmation prompt',
+      default: false
+    })
+  }
+
+  static args = [
+    {
+      name: 'connector',
+      description: 'name of the connector to delete',
+      required: false
+    }
+  ]
+
+  async run (): Promise<void> {
+    const { args, flags } = await this.parse(Delete)
+
+    let connectorName = args.connector
+    if (!connectorName) {
+      connectorName = await CliUx.ux.prompt('Connector name')
+    }
+
+    connectorName = connectorName.trim()
+
+    if (!connectorName) {
+      this.error('Connector name cannot be empty', { exit: 1 })
+    }
+
+    if (flags.verbose) {
+      this.logVerbose('Verbose mode enabled', flags.json)
+      this.logVerbose(`Connector name: ${connectorName}`, flags.json)
+    }
+
+    // Confirmation prompt (skip if --force or --json)
+    if (!flags.force && !flags.json) {
+      const confirmation = await CliUx.ux.prompt(
+        `Are you sure you want to delete connector '${connectorName}'? Type the connector name to confirm`
+      )
+
+      if (confirmation !== connectorName) {
+        this.log(chalk.yellow('Deletion cancelled'))
+        return
+      }
+    }
+
+    const spinner = flags.json ? null : ora('Deleting connector...').start()
+
+    try {
+      const response = await request.requestAPI(
+        `/flowstate/connectors/private/${encodeURIComponent(connectorName)}`,
+        { method: 'DELETE' }
+      )
+
+      spinner?.stop()
+
+      if (flags.verbose) {
+        this.logVerbose(`API response status: ${response.status}`, flags.json)
+        if (response.data) {
+          this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`, flags.json)
+        }
+      }
+
+      // Handle success
+      if (response.status === 200 || response.status === 204) {
+        if (flags.json) {
+          this.log(JSON.stringify({
+            connectorName,
+            status: 'deleted'
+          }, null, 2))
+        } else {
+          this.log(chalk.green(`✓ Connector '${connectorName}' deleted successfully`))
+        }
+      } else {
+        // Non-2xx response - construct error message
+        const errorDetails = response.data?.message || response.data?.error || JSON.stringify(response.data)
+        throw new Error(`Failed to delete connector: HTTP ${response.status} - ${errorDetails}`)
+      }
+    } catch (error) {
+      if (!flags.json) {
+        spinner?.fail(chalk.red('Failed to delete connector'))
+      }
+
+      let errorMessage = (error instanceof Error) ? error.message : String(error)
+
+      // Provide helpful error messages for common cases
+      if (errorMessage.includes('404')) {
+        errorMessage = `Connector '${connectorName}' not found. Use 'zcli connectors:list' to see available connectors.`
+      } else if (errorMessage.includes('403')) {
+        errorMessage = 'Permission denied. You don\'t have access to delete this connector.'
+      }
+
+      if (flags.verbose) {
+        this.logVerbose('\nError Details:', flags.json, 'red')
+        this.logVerbose(errorMessage, flags.json, 'red')
+      }
+
+      this.error(errorMessage, { exit: 1 })
+    }
+  }
+
+  private logVerbose (message: string, isJsonMode: boolean, color?: 'cyan' | 'red'): void {
+    const coloredMessage = color ? chalk[color](message) : chalk.cyan(message)
+    if (isJsonMode) {
+      // Write to stderr to avoid corrupting JSON output on stdout
+      process.stderr.write(coloredMessage + '\n')
+    } else {
+      this.log(coloredMessage)
+    }
+  }
+}

--- a/packages/zcli-connectors/src/commands/connectors/delete.ts
+++ b/packages/zcli-connectors/src/commands/connectors/delete.ts
@@ -3,8 +3,6 @@ import * as chalk from 'chalk'
 import * as ora from 'ora'
 import { request } from '@zendesk/zcli-core'
 
-export const { ux } = CliUx
-
 export default class Delete extends Command {
   static description = 'delete a private connector from your account'
 
@@ -41,7 +39,7 @@ export default class Delete extends Command {
 
     let connectorName = args.connector
     if (!connectorName) {
-      connectorName = await ux.prompt('Connector name')
+      connectorName = await CliUx.ux.prompt('Connector name')
     }
 
     connectorName = connectorName.trim()
@@ -57,7 +55,7 @@ export default class Delete extends Command {
 
     // Confirmation prompt (skip if --force)
     if (!flags.force) {
-      const confirmation = await ux.prompt(
+      const confirmation = await CliUx.ux.prompt(
         `Are you sure you want to delete connector '${connectorName}'? Type the connector name to confirm`
       )
 

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -41,7 +41,7 @@ export default class List extends Command {
       this.logVerbose('Verbose mode enabled')
     }
 
-    const spinner = ora('Fetching connectors...').start()
+    const spinner = (ora as any)('Fetching connectors...').start()
 
     try {
       const response = await request.requestAPI('/flowstate/connectors/private', {
@@ -57,7 +57,7 @@ export default class List extends Command {
 
       const data = response.data as ListConnectorsResponse
 
-      // Handle non-200 responses with human-readable output
+      // Handle non-200 responses
       if (response.status !== 200) {
         const errorMsg = `API returned non-200 status: ${response.status}`
         const responseData = JSON.stringify(response.data, null, 2)

--- a/packages/zcli-connectors/src/commands/connectors/list.ts
+++ b/packages/zcli-connectors/src/commands/connectors/list.ts
@@ -22,16 +22,11 @@ export default class List extends Command {
   static description = 'list all private connectors for the current account'
 
   static examples = [
-    '<%= config.bin %> <%= command.id %>',
-    '<%= config.bin %> <%= command.id %> --json'
+    '<%= config.bin %> <%= command.id %>'
   ]
 
   static flags = {
     help: Flags.help({ char: 'h' }),
-    json: Flags.boolean({
-      description: 'output in JSON format',
-      default: false
-    }),
     verbose: Flags.boolean({
       char: 'v',
       description: 'verbose output',
@@ -43,10 +38,10 @@ export default class List extends Command {
     const { flags } = await this.parse(List)
 
     if (flags.verbose) {
-      this.logVerbose('Verbose mode enabled', flags.json)
+      this.logVerbose('Verbose mode enabled')
     }
 
-    const spinner = flags.json ? null : ora('Fetching connectors...').start()
+    const spinner = ora('Fetching connectors...').start()
 
     try {
       const response = await request.requestAPI('/flowstate/connectors/private', {
@@ -56,25 +51,13 @@ export default class List extends Command {
       spinner?.stop()
 
       if (flags.verbose) {
-        this.logVerbose(`API response status: ${response.status}`, flags.json)
-        this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`, flags.json)
+        this.logVerbose(`API response status: ${response.status}`)
+        this.logVerbose(`Response data: ${JSON.stringify(response.data, null, 2)}`)
       }
 
       const data = response.data as ListConnectorsResponse
 
-      // JSON output mode: always emit JSON to stdout
-      if (flags.json) {
-        if (response.status !== 200) {
-          // Route error to stderr and exit via outer catch; no human-readable output on stdout
-          throw new Error(`API returned non-200 status: ${response.status}`)
-        }
-
-        const connectors = data.connectors ?? []
-        this.log(JSON.stringify(connectors, null, 2))
-        return
-      }
-
-      // Non-JSON output mode: handle non-200 responses with human-readable output
+      // Handle non-200 responses with human-readable output
       if (response.status !== 200) {
         const errorMsg = `API returned non-200 status: ${response.status}`
         const responseData = JSON.stringify(response.data, null, 2)
@@ -91,29 +74,22 @@ export default class List extends Command {
 
       this.displayTable(data.connectors)
     } catch (error) {
-      if (!flags.json) {
-        spinner?.fail(chalk.red('Failed to fetch connectors'))
-      }
+      spinner?.fail(chalk.red('Failed to fetch connectors'))
 
       const errorMessage = (error instanceof Error) ? error.message : String(error)
 
       if (flags.verbose) {
-        this.logVerbose('\nError Details:', flags.json, 'red')
-        this.logVerbose(errorMessage, flags.json)
+        this.logVerbose('\nError Details:', 'red')
+        this.logVerbose(errorMessage)
       }
 
       this.error(errorMessage, { exit: 1 })
     }
   }
 
-  private logVerbose (message: string, isJsonMode: boolean, color?: 'cyan' | 'red'): void {
+  private logVerbose (message: string, color?: 'cyan' | 'red'): void {
     const coloredMessage = color ? chalk[color](message) : chalk.cyan(message)
-    if (isJsonMode) {
-      // Write to stderr to avoid corrupting JSON output on stdout
-      process.stderr.write(coloredMessage + '\n')
-    } else {
-      this.log(coloredMessage)
-    }
+    this.log(coloredMessage)
   }
 
   private displayTable (connectors: ConnectorListItem[]): void {

--- a/packages/zcli-connectors/tests/functional/delete.test.ts
+++ b/packages/zcli-connectors/tests/functional/delete.test.ts
@@ -1,13 +1,12 @@
 /* eslint-disable no-unused-expressions */
 
-import { expect, use } from 'chai'
+import { expect } from 'chai'
 import * as sinon from 'sinon'
-import sinonChai from 'sinon-chai'
-import { CliUx } from '@oclif/core'
 import DeleteCommand from '../../src/commands/connectors/delete'
 import { request } from '@zendesk/zcli-core'
 
-use(sinonChai)
+// Import the underlying deps to stub the prompt function
+import * as deps from '@oclif/core/lib/cli-ux/deps'
 
 describe('delete command', () => {
   let deleteCommand: DeleteCommand
@@ -17,10 +16,15 @@ describe('delete command', () => {
   let promptStub: sinon.SinonStub
 
   beforeEach(() => {
+    // Restore any existing stubs first
+    sinon.restore()
+
+    // Create fresh stubs
     deleteCommand = new DeleteCommand([], {} as any)
     logStub = sinon.stub(deleteCommand, 'log')
     requestAPIStub = sinon.stub(request, 'requestAPI')
-    promptStub = sinon.stub(CliUx.ux, 'prompt')
+    // Stub the underlying prompt function that CliUx.ux.prompt getter returns
+    promptStub = sinon.stub(deps.default.prompt, 'prompt')
   })
 
   afterEach(() => {
@@ -76,11 +80,12 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(requestAPIStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        requestAPIStub,
         '/flowstate/connectors/private/test-connector',
         { method: 'DELETE' }
       )
-      expect(logStub).to.have.been.calledWith(sinon.match(/Connector 'test-connector' deleted successfully/))
+      sinon.assert.calledWith(logStub, sinon.match(/Connector 'test-connector' deleted successfully/))
     })
 
     it('should successfully delete a connector with status 204', async () => {
@@ -91,11 +96,12 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(requestAPIStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        requestAPIStub,
         '/flowstate/connectors/private/test-connector',
         { method: 'DELETE' }
       )
-      expect(logStub).to.have.been.calledWith(sinon.match(/Connector 'test-connector' deleted successfully/))
+      sinon.assert.calledWith(logStub, sinon.match(/Connector 'test-connector' deleted successfully/))
     })
 
     it('should URL-encode connector names with special characters', async () => {
@@ -116,7 +122,8 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(requestAPIStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        requestAPIStub,
         '/flowstate/connectors/private/test%20connector%2Fwith-chars',
         { method: 'DELETE' }
       )
@@ -144,20 +151,21 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(promptStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        promptStub,
         sinon.match(/Are you sure you want to delete connector 'test-connector'/)
       )
-      expect(requestAPIStub).to.have.been.called
+      sinon.assert.called(requestAPIStub)
     })
 
     it('should cancel deletion if confirmation does not match', async () => {
-      promptStub.resolves('wrong-name')
+      promptStub.onFirstCall().resolves('wrong-name')
 
       await deleteCommand.run()
 
-      expect(promptStub).to.have.been.called
-      expect(logStub).to.have.been.calledWith(sinon.match(/Deletion cancelled/))
-      expect(requestAPIStub).to.not.have.been.called
+      sinon.assert.called(promptStub)
+      sinon.assert.calledWith(logStub, sinon.match(/Deletion cancelled/))
+      sinon.assert.notCalled(requestAPIStub)
     })
 
     it('should skip confirmation with --force flag', async () => {
@@ -178,8 +186,8 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(promptStub).to.not.have.been.called
-      expect(requestAPIStub).to.have.been.called
+      sinon.assert.notCalled(promptStub)
+      sinon.assert.called(requestAPIStub)
     })
   })
 
@@ -197,6 +205,7 @@ describe('delete command', () => {
 
     it('should prompt for connector name if not provided', async () => {
       promptStub.onFirstCall().resolves('prompted-connector')
+      promptStub.onSecondCall().resolves('prompted-connector')
       requestAPIStub.resolves({
         status: 200,
         data: {}
@@ -204,8 +213,9 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(promptStub).to.have.been.calledWith('Connector name')
-      expect(requestAPIStub).to.have.been.calledWith(
+      sinon.assert.calledWith(promptStub, 'Connector name')
+      sinon.assert.calledWith(
+        requestAPIStub,
         '/flowstate/connectors/private/prompted-connector',
         { method: 'DELETE' }
       )
@@ -229,7 +239,8 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(requestAPIStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        requestAPIStub,
         '/flowstate/connectors/private/test-connector',
         { method: 'DELETE' }
       )
@@ -257,7 +268,8 @@ describe('delete command', () => {
         // Expected
       }
 
-      expect(errorStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        errorStub,
         'Connector name cannot be empty',
         sinon.match({ exit: 1 })
       )
@@ -284,9 +296,9 @@ describe('delete command', () => {
 
       await deleteCommand.run()
 
-      expect(logStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
-      expect(logStub).to.have.been.calledWith(sinon.match(/Connector name: test-connector/))
-      expect(logStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+      sinon.assert.calledWith(logStub, sinon.match(/Verbose mode enabled/))
+      sinon.assert.calledWith(logStub, sinon.match(/Connector name: test-connector/))
+      sinon.assert.calledWith(logStub, sinon.match(/API response status: 200/))
     })
   })
 
@@ -308,7 +320,7 @@ describe('delete command', () => {
       })
     })
 
-    it('should handle 404 Not Found response with helpful message', async () => {
+    it('should handle 404 Not Found response', async () => {
       requestAPIStub.resolves({
         status: 404,
         data: { error: 'Not Found' }
@@ -321,17 +333,14 @@ describe('delete command', () => {
         // Expected
       }
 
-      expect(errorStub).to.have.been.calledWith(
-        sinon.match(/Connector 'test-connector' not found/),
-        sinon.match({ exit: 1 })
-      )
-      expect(errorStub).to.have.been.calledWith(
-        sinon.match(/zcli connectors:list/),
+      sinon.assert.calledWith(
+        errorStub,
+        sinon.match(/Failed to delete connector: HTTP 404/),
         sinon.match({ exit: 1 })
       )
     })
 
-    it('should handle 403 Forbidden response with helpful message', async () => {
+    it('should handle 403 Forbidden response', async () => {
       requestAPIStub.resolves({
         status: 403,
         data: { error: 'Forbidden' }
@@ -344,8 +353,9 @@ describe('delete command', () => {
         // Expected
       }
 
-      expect(errorStub).to.have.been.calledWith(
-        sinon.match(/Permission denied/),
+      sinon.assert.calledWith(
+        errorStub,
+        sinon.match(/Failed to delete connector: HTTP 403/),
         sinon.match({ exit: 1 })
       )
     })
@@ -363,7 +373,8 @@ describe('delete command', () => {
         // Expected
       }
 
-      expect(errorStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        errorStub,
         sinon.match(/Failed to delete connector/),
         sinon.match({ exit: 1 })
       )
@@ -382,8 +393,9 @@ describe('delete command', () => {
         // Expected
       }
 
-      expect(errorStub).to.have.been.calledWith(
-        sinon.match(/Invalid connector name format/),
+      sinon.assert.calledWith(
+        errorStub,
+        sinon.match(/Failed to delete connector: HTTP 400 - Invalid connector name format/),
         sinon.match({ exit: 1 })
       )
     })
@@ -426,7 +438,8 @@ describe('delete command', () => {
       }
 
       expect(caughtError).to.exist
-      expect(errorStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        errorStub,
         'Network request failed: ECONNREFUSED',
         sinon.match({ exit: 1 })
       )
@@ -444,7 +457,8 @@ describe('delete command', () => {
       }
 
       expect(caughtError).to.exist
-      expect(errorStub).to.have.been.calledWith(
+      sinon.assert.calledWith(
+        errorStub,
         sinon.match(/Authentication failed/),
         sinon.match({ exit: 1 })
       )
@@ -471,8 +485,8 @@ describe('delete command', () => {
         caughtError = error as Error
       }
 
-      expect(logStub).to.have.been.calledWith(sinon.match(/Error Details:/))
-      expect(logStub).to.have.been.calledWith(sinon.match(/Detailed error message/))
+      sinon.assert.calledWith(logStub, sinon.match(/Error Details:/))
+      sinon.assert.calledWith(logStub, sinon.match(/Detailed error message/))
     })
   })
 })

--- a/packages/zcli-connectors/tests/functional/delete.test.ts
+++ b/packages/zcli-connectors/tests/functional/delete.test.ts
@@ -13,7 +13,6 @@ describe('delete command', () => {
   let deleteCommand: DeleteCommand
   let logStub: sinon.SinonStub
   let requestAPIStub: sinon.SinonStub
-  let stderrWriteStub: sinon.SinonStub
   let parseStub: sinon.SinonStub
   let promptStub: sinon.SinonStub
 
@@ -21,7 +20,6 @@ describe('delete command', () => {
     deleteCommand = new DeleteCommand([], {} as any)
     logStub = sinon.stub(deleteCommand, 'log')
     requestAPIStub = sinon.stub(request, 'requestAPI')
-    stderrWriteStub = sinon.stub(process.stderr, 'write')
     promptStub = sinon.stub(CliUx.ux, 'prompt')
   })
 
@@ -32,12 +30,6 @@ describe('delete command', () => {
   describe('command flags', () => {
     it('should have help flag', () => {
       expect(DeleteCommand.flags.help).to.exist
-    })
-
-    it('should have json flag', () => {
-      expect(DeleteCommand.flags.json).to.exist
-      expect(DeleteCommand.flags.json.type).to.equal('boolean')
-      expect(DeleteCommand.flags.json.default).to.equal(false)
     })
 
     it('should have verbose flag with char v', () => {
@@ -69,7 +61,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -112,7 +103,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test connector/with-chars' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -138,7 +128,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: false,
           force: false,
           help: false
@@ -176,32 +165,8 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
-          help: false
-        }
-      })
-
-      requestAPIStub.resolves({
-        status: 200,
-        data: {}
-      })
-
-      await deleteCommand.run()
-
-      expect(promptStub).to.not.have.been.called
-      expect(requestAPIStub).to.have.been.called
-    })
-
-    it('should skip confirmation in JSON mode', async () => {
-      parseStub.restore()
-      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
-        args: { connector: 'test-connector' },
-        flags: {
-          json: true,
-          verbose: false,
-          force: false,
           help: false
         }
       })
@@ -223,7 +188,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: undefined },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -252,7 +216,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: '  test-connector  ' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -277,7 +240,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: '   ' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -302,55 +264,11 @@ describe('delete command', () => {
     })
   })
 
-  describe('JSON output mode', () => {
-    beforeEach(() => {
-      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
-        args: { connector: 'test-connector' },
-        flags: {
-          json: true,
-          verbose: false,
-          force: false,
-          help: false
-        }
-      })
-    })
-
-    it('should output JSON format when --json flag is set', async () => {
-      requestAPIStub.resolves({
-        status: 200,
-        data: {}
-      })
-
-      await deleteCommand.run()
-
-      expect(logStub).to.have.been.calledOnce
-      const outputArg = logStub.firstCall.args[0]
-      const parsedOutput = JSON.parse(outputArg)
-
-      expect(parsedOutput).to.be.an('object')
-      expect(parsedOutput).to.have.property('connectorName', 'test-connector')
-      expect(parsedOutput).to.have.property('status', 'deleted')
-    })
-
-    it('should not output spinner in JSON mode', async () => {
-      requestAPIStub.resolves({
-        status: 200,
-        data: {}
-      })
-
-      await deleteCommand.run()
-
-      // In JSON mode, only JSON output should be on stdout
-      expect(logStub).to.have.been.calledOnce
-    })
-  })
-
   describe('verbose mode', () => {
     beforeEach(() => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: true,
           force: true,
           help: false
@@ -370,36 +288,6 @@ describe('delete command', () => {
       expect(logStub).to.have.been.calledWith(sinon.match(/Connector name: test-connector/))
       expect(logStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
     })
-
-    it('should log verbose messages to stderr in JSON mode', async () => {
-      parseStub.restore()
-      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
-        args: { connector: 'test-connector' },
-        flags: {
-          json: true,
-          verbose: true,
-          force: false,
-          help: false
-        }
-      })
-
-      requestAPIStub.resolves({
-        status: 200,
-        data: {}
-      })
-
-      await deleteCommand.run()
-
-      // Verbose logs should go to stderr, not stdout
-      expect(stderrWriteStub).to.have.been.called
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
-
-      // Only JSON output should be on stdout
-      expect(logStub).to.have.been.calledOnce
-      const outputArg = logStub.firstCall.args[0]
-      expect(() => JSON.parse(outputArg)).to.not.throw()
-    })
   })
 
   describe('error handling - non-2xx responses', () => {
@@ -409,7 +297,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -510,7 +397,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: false,
           force: true,
           help: false
@@ -569,7 +455,6 @@ describe('delete command', () => {
       parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
         args: { connector: 'test-connector' },
         flags: {
-          json: false,
           verbose: true,
           force: true,
           help: false
@@ -588,33 +473,6 @@ describe('delete command', () => {
 
       expect(logStub).to.have.been.calledWith(sinon.match(/Error Details:/))
       expect(logStub).to.have.been.calledWith(sinon.match(/Detailed error message/))
-    })
-
-    it('should route verbose error details to stderr in JSON mode', async () => {
-      parseStub.restore()
-      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
-        args: { connector: 'test-connector' },
-        flags: {
-          json: true,
-          verbose: true,
-          force: false,
-          help: false
-        }
-      })
-
-      const detailedError = new Error('Error in JSON mode')
-      requestAPIStub.rejects(detailedError)
-
-      try {
-        await deleteCommand.run()
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        caughtError = error as Error
-      }
-
-      // Verbose error details should go to stderr
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error Details:/))
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error in JSON mode/))
     })
   })
 })

--- a/packages/zcli-connectors/tests/functional/delete.test.ts
+++ b/packages/zcli-connectors/tests/functional/delete.test.ts
@@ -1,0 +1,620 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect, use } from 'chai'
+import * as sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import { CliUx } from '@oclif/core'
+import DeleteCommand from '../../src/commands/connectors/delete'
+import { request } from '@zendesk/zcli-core'
+
+use(sinonChai)
+
+describe('delete command', () => {
+  let deleteCommand: DeleteCommand
+  let logStub: sinon.SinonStub
+  let requestAPIStub: sinon.SinonStub
+  let stderrWriteStub: sinon.SinonStub
+  let parseStub: sinon.SinonStub
+  let promptStub: sinon.SinonStub
+
+  beforeEach(() => {
+    deleteCommand = new DeleteCommand([], {} as any)
+    logStub = sinon.stub(deleteCommand, 'log')
+    requestAPIStub = sinon.stub(request, 'requestAPI')
+    stderrWriteStub = sinon.stub(process.stderr, 'write')
+    promptStub = sinon.stub(CliUx.ux, 'prompt')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('command flags', () => {
+    it('should have help flag', () => {
+      expect(DeleteCommand.flags.help).to.exist
+    })
+
+    it('should have json flag', () => {
+      expect(DeleteCommand.flags.json).to.exist
+      expect(DeleteCommand.flags.json.type).to.equal('boolean')
+      expect(DeleteCommand.flags.json.default).to.equal(false)
+    })
+
+    it('should have verbose flag with char v', () => {
+      expect(DeleteCommand.flags.verbose).to.exist
+      expect(DeleteCommand.flags.verbose.char).to.equal('v')
+      expect(DeleteCommand.flags.verbose.type).to.equal('boolean')
+      expect(DeleteCommand.flags.verbose.default).to.equal(false)
+    })
+
+    it('should have force flag with char f', () => {
+      expect(DeleteCommand.flags.force).to.exist
+      expect(DeleteCommand.flags.force.char).to.equal('f')
+      expect(DeleteCommand.flags.force.type).to.equal('boolean')
+      expect(DeleteCommand.flags.force.default).to.equal(false)
+    })
+  })
+
+  describe('command arguments', () => {
+    it('should have connector argument', () => {
+      expect(DeleteCommand.args).to.exist
+      expect(DeleteCommand.args).to.have.lengthOf(1)
+      expect(DeleteCommand.args[0].name).to.equal('connector')
+      expect(DeleteCommand.args[0].required).to.equal(false)
+    })
+  })
+
+  describe('successful delete operations', () => {
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+    })
+
+    it('should successfully delete a connector with status 200', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { message: 'Connector deleted' }
+      })
+
+      await deleteCommand.run()
+
+      expect(requestAPIStub).to.have.been.calledWith(
+        '/flowstate/connectors/private/test-connector',
+        { method: 'DELETE' }
+      )
+      expect(logStub).to.have.been.calledWith(sinon.match(/Connector 'test-connector' deleted successfully/))
+    })
+
+    it('should successfully delete a connector with status 204', async () => {
+      requestAPIStub.resolves({
+        status: 204,
+        data: null
+      })
+
+      await deleteCommand.run()
+
+      expect(requestAPIStub).to.have.been.calledWith(
+        '/flowstate/connectors/private/test-connector',
+        { method: 'DELETE' }
+      )
+      expect(logStub).to.have.been.calledWith(sinon.match(/Connector 'test-connector' deleted successfully/))
+    })
+
+    it('should URL-encode connector names with special characters', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test connector/with-chars' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(requestAPIStub).to.have.been.calledWith(
+        '/flowstate/connectors/private/test%20connector%2Fwith-chars',
+        { method: 'DELETE' }
+      )
+    })
+  })
+
+  describe('confirmation prompt', () => {
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: false,
+          help: false
+        }
+      })
+    })
+
+    it('should require confirmation when force flag is not set', async () => {
+      promptStub.resolves('test-connector')
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(promptStub).to.have.been.calledWith(
+        sinon.match(/Are you sure you want to delete connector 'test-connector'/)
+      )
+      expect(requestAPIStub).to.have.been.called
+    })
+
+    it('should cancel deletion if confirmation does not match', async () => {
+      promptStub.resolves('wrong-name')
+
+      await deleteCommand.run()
+
+      expect(promptStub).to.have.been.called
+      expect(logStub).to.have.been.calledWith(sinon.match(/Deletion cancelled/))
+      expect(requestAPIStub).to.not.have.been.called
+    })
+
+    it('should skip confirmation with --force flag', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(promptStub).to.not.have.been.called
+      expect(requestAPIStub).to.have.been.called
+    })
+
+    it('should skip confirmation in JSON mode', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: true,
+          verbose: false,
+          force: false,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(promptStub).to.not.have.been.called
+      expect(requestAPIStub).to.have.been.called
+    })
+  })
+
+  describe('connector name prompting', () => {
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: undefined },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+    })
+
+    it('should prompt for connector name if not provided', async () => {
+      promptStub.onFirstCall().resolves('prompted-connector')
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(promptStub).to.have.been.calledWith('Connector name')
+      expect(requestAPIStub).to.have.been.calledWith(
+        '/flowstate/connectors/private/prompted-connector',
+        { method: 'DELETE' }
+      )
+    })
+
+    it('should trim whitespace from connector name', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: '  test-connector  ' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(requestAPIStub).to.have.been.calledWith(
+        '/flowstate/connectors/private/test-connector',
+        { method: 'DELETE' }
+      )
+    })
+
+    it('should error if connector name is empty after trimming', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: '   ' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+
+      const errorStub = sinon.stub(deleteCommand, 'error').callsFake((message: any) => {
+        throw new Error(String(message))
+      })
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected
+      }
+
+      expect(errorStub).to.have.been.calledWith(
+        'Connector name cannot be empty',
+        sinon.match({ exit: 1 })
+      )
+    })
+  })
+
+  describe('JSON output mode', () => {
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: true,
+          verbose: false,
+          force: false,
+          help: false
+        }
+      })
+    })
+
+    it('should output JSON format when --json flag is set', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      const parsedOutput = JSON.parse(outputArg)
+
+      expect(parsedOutput).to.be.an('object')
+      expect(parsedOutput).to.have.property('connectorName', 'test-connector')
+      expect(parsedOutput).to.have.property('status', 'deleted')
+    })
+
+    it('should not output spinner in JSON mode', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      // In JSON mode, only JSON output should be on stdout
+      expect(logStub).to.have.been.calledOnce
+    })
+  })
+
+  describe('verbose mode', () => {
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: true,
+          force: true,
+          help: false
+        }
+      })
+    })
+
+    it('should log verbose messages to stdout in normal mode', async () => {
+      requestAPIStub.resolves({
+        status: 200,
+        data: { message: 'Deleted' }
+      })
+
+      await deleteCommand.run()
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/Connector name: test-connector/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+    })
+
+    it('should log verbose messages to stderr in JSON mode', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: true,
+          verbose: true,
+          force: false,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 200,
+        data: {}
+      })
+
+      await deleteCommand.run()
+
+      // Verbose logs should go to stderr, not stdout
+      expect(stderrWriteStub).to.have.been.called
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
+
+      // Only JSON output should be on stdout
+      expect(logStub).to.have.been.calledOnce
+      const outputArg = logStub.firstCall.args[0]
+      expect(() => JSON.parse(outputArg)).to.not.throw()
+    })
+  })
+
+  describe('error handling - non-2xx responses', () => {
+    let errorStub: sinon.SinonStub
+
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+
+      errorStub = sinon.stub(deleteCommand, 'error').callsFake((message: any) => {
+        throw new Error(String(message))
+      })
+    })
+
+    it('should handle 404 Not Found response with helpful message', async () => {
+      requestAPIStub.resolves({
+        status: 404,
+        data: { error: 'Not Found' }
+      })
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected
+      }
+
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Connector 'test-connector' not found/),
+        sinon.match({ exit: 1 })
+      )
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/zcli connectors:list/),
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should handle 403 Forbidden response with helpful message', async () => {
+      requestAPIStub.resolves({
+        status: 403,
+        data: { error: 'Forbidden' }
+      })
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected
+      }
+
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Permission denied/),
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should handle 500 Internal Server Error response', async () => {
+      requestAPIStub.resolves({
+        status: 500,
+        data: { error: 'Internal Server Error' }
+      })
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected
+      }
+
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Failed to delete connector/),
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should handle error responses with message field', async () => {
+      requestAPIStub.resolves({
+        status: 400,
+        data: { message: 'Invalid connector name format' }
+      })
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected
+      }
+
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Invalid connector name format/),
+        sinon.match({ exit: 1 })
+      )
+    })
+  })
+
+  describe('error handling - API failures', () => {
+    let errorStub: sinon.SinonStub
+    let caughtError: Error | undefined
+
+    beforeEach(() => {
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: false,
+          force: true,
+          help: false
+        }
+      })
+
+      errorStub = sinon.stub(deleteCommand, 'error').callsFake((message: any, options: any) => {
+        const err = new Error(String(message))
+        ;(err as any).options = options
+        throw err
+      })
+    })
+
+    afterEach(() => {
+      caughtError = undefined
+    })
+
+    it('should handle network errors', async () => {
+      const networkError = new Error('Network request failed: ECONNREFUSED')
+      requestAPIStub.rejects(networkError)
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(caughtError).to.exist
+      expect(errorStub).to.have.been.calledWith(
+        'Network request failed: ECONNREFUSED',
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should handle authentication errors', async () => {
+      const authError = new Error('Authentication failed: Invalid credentials')
+      requestAPIStub.rejects(authError)
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(caughtError).to.exist
+      expect(errorStub).to.have.been.calledWith(
+        sinon.match(/Authentication failed/),
+        sinon.match({ exit: 1 })
+      )
+    })
+
+    it('should log verbose error details when verbose flag is set', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: false,
+          verbose: true,
+          force: true,
+          help: false
+        }
+      })
+
+      const detailedError = new Error('Detailed error message')
+      requestAPIStub.rejects(detailedError)
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      expect(logStub).to.have.been.calledWith(sinon.match(/Error Details:/))
+      expect(logStub).to.have.been.calledWith(sinon.match(/Detailed error message/))
+    })
+
+    it('should route verbose error details to stderr in JSON mode', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          json: true,
+          verbose: true,
+          force: false,
+          help: false
+        }
+      })
+
+      const detailedError = new Error('Error in JSON mode')
+      requestAPIStub.rejects(detailedError)
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        caughtError = error as Error
+      }
+
+      // Verbose error details should go to stderr
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error Details:/))
+      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error in JSON mode/))
+    })
+  })
+})

--- a/packages/zcli-connectors/tests/functional/list.test.ts
+++ b/packages/zcli-connectors/tests/functional/list.test.ts
@@ -12,7 +12,6 @@ describe('list command', () => {
   let listCommand: ListCommand
   let logStub: sinon.SinonStub
   let requestAPIStub: sinon.SinonStub
-  let stderrWriteStub: sinon.SinonStub
   let parseStub: sinon.SinonStub
 
   const mockConnectorData = [
@@ -40,7 +39,6 @@ describe('list command', () => {
     listCommand = new ListCommand([], {} as any)
     logStub = sinon.stub(listCommand, 'log')
     requestAPIStub = sinon.stub(request, 'requestAPI')
-    stderrWriteStub = sinon.stub(process.stderr, 'write')
   })
 
   afterEach(() => {
@@ -50,12 +48,6 @@ describe('list command', () => {
   describe('command flags', () => {
     it('should have help flag', () => {
       expect(ListCommand.flags.help).to.exist
-    })
-
-    it('should have json flag', () => {
-      expect(ListCommand.flags.json).to.exist
-      expect(ListCommand.flags.json.type).to.equal('boolean')
-      expect(ListCommand.flags.json.default).to.equal(false)
     })
 
     it('should have verbose flag with char v', () => {
@@ -70,7 +62,6 @@ describe('list command', () => {
     beforeEach(() => {
       parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
-          json: false,
           verbose: false,
           help: false
         }
@@ -125,69 +116,10 @@ describe('list command', () => {
     })
   })
 
-  describe('JSON output mode', () => {
-    beforeEach(() => {
-      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
-        flags: {
-          json: true,
-          verbose: false,
-          help: false
-        }
-      })
-    })
-
-    it('should output JSON format when --json flag is set', async () => {
-      requestAPIStub.resolves({
-        status: 200,
-        data: { connectors: mockConnectorData }
-      })
-
-      await listCommand.run()
-
-      expect(logStub).to.have.been.calledOnce
-      const outputArg = logStub.firstCall.args[0]
-      const parsedOutput = JSON.parse(outputArg)
-
-      expect(parsedOutput).to.be.an('array')
-      expect(parsedOutput).to.have.lengthOf(2)
-      expect(parsedOutput[0]).to.have.property('connector_name', 'test-connector-1')
-      expect(parsedOutput[1]).to.have.property('connector_name', 'test-connector-2')
-    })
-
-    it('should output empty JSON array when no connectors exist', async () => {
-      requestAPIStub.resolves({
-        status: 200,
-        data: { connectors: [] }
-      })
-
-      await listCommand.run()
-
-      expect(logStub).to.have.been.calledOnce
-      const outputArg = logStub.firstCall.args[0]
-      const parsedOutput = JSON.parse(outputArg)
-
-      expect(parsedOutput).to.be.an('array')
-      expect(parsedOutput).to.have.lengthOf(0)
-    })
-
-    it('should not output spinner in JSON mode', async () => {
-      requestAPIStub.resolves({
-        status: 200,
-        data: { connectors: mockConnectorData }
-      })
-
-      await listCommand.run()
-
-      // In JSON mode, no spinner-related logs should be on stdout
-      expect(logStub).to.have.been.calledOnce
-    })
-  })
-
   describe('verbose mode', () => {
     beforeEach(() => {
       parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
-          json: false,
           verbose: true,
           help: false
         }
@@ -205,41 +137,12 @@ describe('list command', () => {
       expect(logStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
       expect(logStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
     })
-
-    it('should log verbose messages to stderr in JSON mode', async () => {
-      parseStub.restore()
-      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
-        flags: {
-          json: true,
-          verbose: true,
-          help: false
-        }
-      })
-
-      requestAPIStub.resolves({
-        status: 200,
-        data: { connectors: mockConnectorData }
-      })
-
-      await listCommand.run()
-
-      // Verbose logs should go to stderr, not stdout
-      expect(stderrWriteStub).to.have.been.called
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Verbose mode enabled/))
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/API response status: 200/))
-
-      // Only JSON output should be on stdout
-      expect(logStub).to.have.been.calledOnce
-      const outputArg = logStub.firstCall.args[0]
-      expect(() => JSON.parse(outputArg)).to.not.throw()
-    })
   })
 
   describe('error handling - non-200 responses', () => {
     beforeEach(() => {
       parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
-          json: false,
           verbose: false,
           help: false
         }
@@ -267,40 +170,6 @@ describe('list command', () => {
 
       expect(logStub).to.have.been.calledWith(sinon.match(/API returned non-200 status: 500/))
     })
-
-    it('should route non-200 errors to stderr in JSON mode', async () => {
-      parseStub.restore()
-      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
-        flags: {
-          json: true,
-          verbose: false,
-          help: false
-        }
-      })
-
-      const errorStub = sinon.stub(listCommand, 'error').callsFake((message: any) => {
-        const err = new Error(String(message))
-        throw err
-      })
-
-      requestAPIStub.resolves({
-        status: 404,
-        data: { error: 'Not Found' }
-      })
-
-      try {
-        await listCommand.run()
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        // Expected to throw
-      }
-
-      // Error should go through this.error() in JSON mode
-      expect(errorStub).to.have.been.calledWith(
-        'API returned non-200 status: 404',
-        sinon.match({ exit: 1 })
-      )
-    })
   })
 
   describe('error handling - API failures', () => {
@@ -310,7 +179,6 @@ describe('list command', () => {
     beforeEach(() => {
       parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
-          json: false,
           verbose: false,
           help: false
         }
@@ -367,7 +235,6 @@ describe('list command', () => {
       parseStub.restore()
       parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
-          json: false,
           verbose: true,
           help: false
         }
@@ -386,38 +253,12 @@ describe('list command', () => {
       expect(logStub).to.have.been.calledWith(sinon.match(/Error Details:/))
       expect(logStub).to.have.been.calledWith(sinon.match(/Detailed error message/))
     })
-
-    it('should route verbose error details to stderr in JSON mode', async () => {
-      parseStub.restore()
-      parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
-        flags: {
-          json: true,
-          verbose: true,
-          help: false
-        }
-      })
-
-      const detailedError = new Error('Error in JSON mode')
-      requestAPIStub.rejects(detailedError)
-
-      try {
-        await listCommand.run()
-        expect.fail('Should have thrown an error')
-      } catch (error) {
-        caughtError = error as Error
-      }
-
-      // Verbose error details should go to stderr
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error Details:/))
-      expect(stderrWriteStub).to.have.been.calledWith(sinon.match(/Error in JSON mode/))
-    })
   })
 
   describe('API response edge cases', () => {
     beforeEach(() => {
       parseStub = sinon.stub(listCommand, 'parse' as any).resolves({
         flags: {
-          json: false,
           verbose: false,
           help: false
         }


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->
JIRA :  https://zendesk.atlassian.net/browse/VEG-3621
## Description

Adds a new zcli connectors delete command to remove private connectors from your account, with comprehensive test coverage and cleanup of JSON mode handling.

Key changes:

 New delete command with interactive and non-interactive modes
Supports --force flag to skip confirmation prompt
Handles connector name as argument or via interactive prompt
 Removed --json flag from list command (simplified output handling)

Usage:

```

zcli connectors delete my-connector          # with confirmation
zcli connectors delete my-connector --force  # skip confirmation
zcli connectors delete  

```

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`6b37377`](https://github.com/zendesk/zcli/pull/348/commits/6b373775ac438ed30729cd9692954db7ef438d27) feat: adding zcli delete command



### [`b668f86`](https://github.com/zendesk/zcli/pull/348/commits/b668f86fee8eb3c2a6f8cf3c246a7da6b49aed6f) fix: removing json flag for zcli



### [`811350d`](https://github.com/zendesk/zcli/pull/348/commits/811350de94c14560e1079040a378dd08a5811461) fix: addressing review comments for delete command

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>

### [`d98ce2e`](https://github.com/zendesk/zcli/pull/348/commits/d98ce2e9283b27c45662ff8677af1f61a4262dbc) fix: fixing json mode remainder



### [`d121777`](https://github.com/zendesk/zcli/pull/348/commits/d121777494049abbb52a15d120f22ba5cf1580a4) fix: fixing failing tests



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
