### PR TITLE
chore: fix `yarn run test` to run `packages/zcli-connectors` unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "git:check": "./scripts/git_check.sh",
     "link:bin": "bash ./scripts/link_dev.sh",
     "lint": "eslint . --ext .ts --config .eslintrc",
-    "test": "nyc --extension .ts mocha --config=.mocharc.json --forbid-only packages/**/src/**/*.test.ts",
-    "test:functional": "mocha --config=.mocharc.json -r ts-node/register packages/**/tests/**/*.test.ts",
+    "test": "nyc --extension .ts mocha --config=.mocharc.json --forbid-only 'packages/**/src/**/*.test.ts'",
+    "test:functional": "mocha --config=.mocharc.json -r ts-node/register 'packages/**/tests/**/*.test.ts'",
     "changelog": "lerna-changelog",
     "type:check": "lerna run type:check"
   },


### PR DESCRIPTION
## Description
Fix Test CI to run all unit tests.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`fa71e5f`](https://github.com/zendesk/zcli/pull/350/commits/fa71e5faf5d09f02e96694caae11f7cde110527a) chore: fix `yarn run test` to run `packages/zcli-connectors` unit tests

The unit tests within `packages/zcli-connectors` were not being picked up by
`yarn run test` because they are nested under an extra subfolder (e.g.
`packages/zcli-connectors/src/lib/manifest-generator/generator.test.ts`)
compared to the other packages.

The problem was caused by yarn scripts being run the system shell by default,
which normally doesn't support globstar (**) by default like `zsh`, so when
expanding `packages/**/src/**/*.test.ts`, only the folders in `packages/**/src/`
are matched like `packages/**/src/*/*.test.ts`[^1].

Passing the glob pattern as a string, delays its expansion so `mocha` can handle
it correctly independently of the environment, making the behavior consistent.

[^1]: https://www.linuxjournal.com/content/globstar-new-bash-globbing-option


<!-- === GH HISTORY FENCE === -->

## Detail

- https://zendesk.atlassian.net/browse/APPS-8171

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
