### PR TITLE
fix: include connector starter template files in npm package

### DIFF
--- a/packages/zcli-connectors/package.json
+++ b/packages/zcli-connectors/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepack": "tsc && ../../scripts/prepack.sh",
+    "prepack": "tsc && cp -r src/templates dist/templates && ../../scripts/prepack.sh",
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json && rm -rf ./dist && git checkout ./package.json",
     "type:check": "tsc"
   },


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
Removed src/templates/**/* from the exclude list in packages/zcli-connectors/tsconfig.json so that the starter template files are compiled and included in the published npm package

Context:
Previously, the starter template files were excluded from TypeScript compilation, which meant they were not present in the dist/ output when the package was published. This caused `zcli connectors:create` to fail for users installing zcli from npm, as the template directory it copies from would be empty.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`780de25`](https://github.com/zendesk/zcli/pull/352/commits/780de2571410717ef4a42c37ac9ae21ee02b74b9) Include the template files in the npm package



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
