### PR TITLE
fix: use project-local tsc for type checking

### DIFF
--- a/packages/zcli-connectors/src/commands/connectors/bundle.ts
+++ b/packages/zcli-connectors/src/commands/connectors/bundle.ts
@@ -107,7 +107,14 @@ export default class Bundle extends Command {
       }
 
       spinner.text = chalk.cyan('Running TypeScript type check...')
-      execFileSync('tsc', ['--noEmit', '--project', projectPath], { stdio: 'inherit' })
+      const tscBinaryName = process.platform === 'win32' ? 'tsc.cmd' : 'tsc'
+      const tscPath = join(projectPath, 'node_modules/.bin', tscBinaryName)
+      if (!existsSync(tscPath)) {
+        spinner.stop()
+        spinner.info(chalk.yellow('TypeScript not found in node_modules/.bin/tsc, skipping type check.'))
+        return
+      }
+      execFileSync(tscPath, ['--noEmit', '--project', projectPath], { stdio: 'inherit' })
       spinner.succeed(chalk.green('TypeScript compilation check passed'))
     } catch (error) {
       spinner.fail(chalk.red('TypeScript type check failed'))

--- a/packages/zcli-connectors/tests/functional/bundle.test.ts
+++ b/packages/zcli-connectors/tests/functional/bundle.test.ts
@@ -20,7 +20,10 @@ describe('bundle', () => {
     fsStubs = {
       existsSync: sinon.stub(fs, 'existsSync').callsFake((path: fs.PathLike) => {
         const pathStr = String(path)
-        // Return false for tsconfig.json (to skip type check) and for non-existent connector dirs in specific tests
+        // Return false for tsconfig.json to skip the type check in most tests.
+        // node_modules/.bin/tsc is only reached when tsconfig.json exists, so it
+        // doesn't need special-casing here — tests that exercise the tsc path
+        // override existsSync directly.
         if (pathStr.includes('tsconfig.json')) return false
         if (pathStr.includes('/nonexistent') || pathStr.includes('\\nonexistent')) return false
         return true // connector root and dist directories exist by default
@@ -160,6 +163,24 @@ describe('bundle', () => {
     )
   })
 
+  it('should skip type check when node_modules/.bin/tsc does not exist', async () => {
+    (bundleCommand as any).parse = sinon.stub().resolves({
+      args: { path: './test-dir' },
+      flags: { watch: false, verbose: false }
+    })
+
+    fsStubs.existsSync.callsFake((path: fs.PathLike) => {
+      const pathStr = String(path)
+      if (/node_modules[\\/]\.bin[\\/]tsc(\.cmd)?$/.test(pathStr)) return false
+      if (pathStr.includes('/nonexistent') || pathStr.includes('\\nonexistent')) return false
+      return true
+    })
+
+    await bundleCommand.run()
+
+    expect(viteStubs.run).to.have.been.called
+  })
+
   it('should fail bundle if TypeScript compilation fails', async () => {
     (bundleCommand as any).parse = sinon.stub().resolves({
       args: { path: './test-dir' },
@@ -168,8 +189,7 @@ describe('bundle', () => {
 
     fsStubs.existsSync.returns(true)
 
-    const execSyncStub = sinon.stub(childProcess, 'execFileSync')
-    execSyncStub.throws(new Error('TypeScript compilation error'))
+    const execSyncStub = sinon.stub(childProcess, 'execFileSync').throws(new Error('TypeScript compilation error'))
 
     try {
       await bundleCommand.run()


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
`connectors:bundle` — replace execFileSync('tsc', ...) with the connector project's own node_modules/.bin/tsc, so the TypeScript version used for type checking always matches what the connector declares as a dependency. If node_modules/.bin/tsc is not found, the type check is skipped with an informative message. 

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`d51c611`](https://github.com/zendesk/zcli/pull/353/commits/d51c61187e327ef2db227887ff03c611160ffd02) fix: use project-local tsc for type checking



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
