### PR TITLE
 fix: dedicated 404 error handling and improved error messages for connectors delete command

### DIFF
--- a/packages/zcli-connectors/src/commands/connectors/delete.ts
+++ b/packages/zcli-connectors/src/commands/connectors/delete.ts
@@ -85,6 +85,13 @@ export default class Delete extends Command {
       // Handle response
       if (response.status === 200 || response.status === 204) {
         this.log(chalk.green(`✓ Connector '${connectorName}' deleted successfully`))
+      } else if (response.status === 404) {
+        const errorMessage = `Connector '${connectorName}' not found. It may have already been deleted or does not exist.`
+        if (flags.verbose) {
+          this.logVerbose('\nError Details:', 'red')
+          this.logVerbose(errorMessage, 'red')
+        }
+        this.error(errorMessage, { exit: 1 })
       } else {
         // Handle error response
         spinner?.stop()

--- a/packages/zcli-connectors/tests/functional/delete.test.ts
+++ b/packages/zcli-connectors/tests/functional/delete.test.ts
@@ -320,7 +320,7 @@ describe('delete command', () => {
       })
     })
 
-    it('should handle 404 Not Found response', async () => {
+    it('should handle 404 Not Found response with specific not-found message', async () => {
       requestAPIStub.resolves({
         status: 404,
         data: { error: 'Not Found' }
@@ -335,9 +335,36 @@ describe('delete command', () => {
 
       sinon.assert.calledWith(
         errorStub,
-        sinon.match(/Failed to delete connector: HTTP 404/),
+        sinon.match(/Connector 'test-connector' not found\. It may have already been deleted or does not exist\./),
         sinon.match({ exit: 1 })
       )
+    })
+
+    it('should log verbose error details on 404 when verbose flag is set', async () => {
+      parseStub.restore()
+      parseStub = sinon.stub(deleteCommand, 'parse' as any).resolves({
+        args: { connector: 'test-connector' },
+        flags: {
+          verbose: true,
+          force: true,
+          help: false
+        }
+      })
+
+      requestAPIStub.resolves({
+        status: 404,
+        data: { error: 'Not Found' }
+      })
+
+      try {
+        await deleteCommand.run()
+        expect.fail('Should have thrown an error')
+      } catch (error) {
+        // Expected
+      }
+
+      sinon.assert.calledWith(logStub, sinon.match(/Error Details:/))
+      sinon.assert.calledWith(logStub, sinon.match(/not found/))
     })
 
     it('should handle 403 Forbidden response', async () => {


### PR DESCRIPTION
Change:

 **`zcli connectors:delete` command**: adds a dedicated `404` branch that surfaces a clear, user-facing message ("Connector '...' not found. It may have already been deleted or does not exist.")

<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`103fb63`](https://github.com/zendesk/zcli/pull/354/commits/103fb634af7e33459c1034ba8f68a3c3baf5e673) fix: dedicated 404 error handling and improved error messages for connectors delete command



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
