### PR TITLE
ci: added history fence to the PR description and updated publish com…

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -84,18 +84,21 @@ jobs:
             --base master \
             --head $RELEASE_BRANCH \
             --title "chore(release): v$VERSION" \
-            --body "## Release v$VERSION
-          Version bump and changelog updates.
+            --body "$(cat <<EOF
+## Release v$VERSION
+Version bump and changelog updates.
 
-          Triggered by: ${{ github.actor }}
+Triggered by: ${{ github.actor }}
 
-          <!-- === GH HISTORY FORMAT FENCE === -->
-          <!--
-          ### [\`%h\`]({{.url}}/commits/%H) %s%n%n%b%n
-          -->
-          <!-- === GH HISTORY FORMAT FENCE === -->
-          <!-- === GH HISTORY FENCE === -->
-          Do NOT write here! This section will be filled in by GitHub Action
-          automatically. If you don't want this, either remove the markers or write
-          outside the fences.
-          <!-- === GH HISTORY FENCE === -->"
+<!-- === GH HISTORY FORMAT FENCE === -->
+<!--
+### [\`%h\`]({{.url}}/commits/%H) %s%n%n%b%n
+-->
+<!-- === GH HISTORY FORMAT FENCE === -->
+<!-- === GH HISTORY FENCE === -->
+Do NOT write here! This section will be filled in by GitHub Action
+automatically. If you don't want this, either remove the markers or write
+outside the fences.
+<!-- === GH HISTORY FENCE === -->
+EOF
+)"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -87,4 +87,15 @@ jobs:
             --body "## Release v$VERSION
           Version bump and changelog updates.
 
-          Triggered by: ${{ github.actor }}"
+          Triggered by: ${{ github.actor }}
+
+          <!-- === GH HISTORY FORMAT FENCE === -->
+          <!--
+          ### [\`%h\`]({{.url}}/commits/%H) %s%n%n%b%n
+          -->
+          <!-- === GH HISTORY FORMAT FENCE === -->
+          <!-- === GH HISTORY FENCE === -->
+          Do NOT write here! This section will be filled in by GitHub Action
+          automatically. If you don't want this, either remove the markers or write
+          outside the fences.
+          <!-- === GH HISTORY FENCE === -->"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -90,11 +90,9 @@ jobs:
 
           Triggered by: ${{ github.actor }}
 
-          <!-- === GH HISTORY FORMAT FENCE === -->
-          <!--
+          <!-- === GH HISTORY FORMAT FENCE === --> <!--
           ### [\`%h\`]({{.url}}/commits/%H) %s%n%n%b%n
-          -->
-          <!-- === GH HISTORY FORMAT FENCE === -->
+          --> <!-- === GH HISTORY FORMAT FENCE === -->
           <!-- === GH HISTORY FENCE === -->
           Do NOT write here! This section will be filled in by GitHub Action
           automatically. If you don't want this, either remove the markers or write

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -84,23 +84,6 @@ jobs:
             --base master \
             --head $RELEASE_BRANCH \
             --title "chore(release): v$VERSION" \
-            --body "$(cat <<EOF
-## Release v$VERSION
-Version bump and changelog updates.
-
-Triggered by: ${{ github.actor }}
-
-<!-- === GH HISTORY FORMAT FENCE === -->
-<!--
-### [\`%h\`]({{.url}}/commits/%H) %s%n%n%b%n
--->
-<!-- === GH HISTORY FORMAT FENCE === -->
-<!-- === GH HISTORY FENCE === -->
-Do NOT write here! This section will be filled in by GitHub Action
-automatically. If you don't want this, either remove the markers or write
-outside the fences.
-<!-- === GH HISTORY FENCE === -->
-EOF
             --body-file - <<EOF
           ## Release v$VERSION
           Version bump and changelog updates.

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -101,4 +101,20 @@ automatically. If you don't want this, either remove the markers or write
 outside the fences.
 <!-- === GH HISTORY FENCE === -->
 EOF
-)"
+            --body-file - <<EOF
+          ## Release v$VERSION
+          Version bump and changelog updates.
+
+          Triggered by: ${{ github.actor }}
+
+          <!-- === GH HISTORY FORMAT FENCE === -->
+          <!--
+          ### [\`%h\`]({{.url}}/commits/%H) %s%n%n%b%n
+          -->
+          <!-- === GH HISTORY FORMAT FENCE === -->
+          <!-- === GH HISTORY FENCE === -->
+          Do NOT write here! This section will be filled in by GitHub Action
+          automatically. If you don't want this, either remove the markers or write
+          outside the fences.
+          <!-- === GH HISTORY FENCE === -->
+          EOF

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           TOTP=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
 
-          yarn lerna publish from-git \
+          yarn lerna publish from-package \
             --yes \
             --no-verify-access \
             --otp $TOTP


### PR DESCRIPTION


<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

Change: Added history fence to the release PR description and updated npm publish command from `from-git` to `from-package`.

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`cf6551d`](https://github.com/zendesk/zcli/pull/357/commits/cf6551d247abbbae5daa3d2c36b5a2e716ac27e9) ci: added history fence to the PR description and updated publish command



### [`c72f6d5`](https://github.com/zendesk/zcli/pull/357/commits/c72f6d53c4e2145ec307317163f1812cbeb46210) corrected indentation



### [`a9a5f86`](https://github.com/zendesk/zcli/pull/357/commits/a9a5f86f38bd315cc0b2aa1e13abc609e42a6b1f) Update .github/workflows/create-release-pr.yml

Co-authored-by: Marcio Horoiwa <marcio.massaki@gmail.com>

### [`fb6ad26`](https://github.com/zendesk/zcli/pull/357/commits/fb6ad2606bb8fae7a7148cb0c14b85e064a15843) using --body-file to insert fence



### [`5fff0bc`](https://github.com/zendesk/zcli/pull/357/commits/5fff0bc5eebe1ae0101fa60fd10fdaf43f570bb8) Updated fence placeholder



<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
