### PR TITLE
chore: simplify npm publish workflow and other improvements

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       release-type:
-        description: 'Release type. `--conventional-prerelease` for prerelease or `--conventional-graduate` for stable.'
+        description: Release type. `--conventional-prerelease` for prerelease or `--conventional-graduate` for stable.
         required: true
         type: choice
         options:
-          - '--conventional-prerelease --preid beta'
-          - '--conventional-graduate'
+          - --conventional-prerelease --preid beta
+          - --conventional-graduate
 
 concurrency:
-  group: "release-pr"
+  group: release-pr
   cancel-in-progress: false
 
 jobs:
@@ -33,8 +33,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
-          cache: "yarn"
+          node-version-file: .node-version
+          cache: yarn
 
       - name: Configure git
         run: |

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'lerna.json'
+      - lerna.json
 
 jobs:
   create-tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to NPM
 on:
   push:
     tags:
-      - 'v*'
+      - v*
 
 permissions:
   contents: read
@@ -19,8 +19,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.node-version'
-          cache: 'yarn'
+          node-version-file: .node-version
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           TOTP=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
 
-          yarn lerna publish from-package \
+          yarn --silent lerna publish from-package \
             --yes \
             --otp $TOTP
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,6 @@ jobs:
 
           yarn lerna publish from-package \
             --yes \
-            --no-verify-access \
             --otp $TOTP
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,18 +32,8 @@ jobs:
 
       - name: Configure NPM Authentication
         run: |
-          cat << EOF > .npmrc
-          //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          registry=https://registry.npmjs.org/
-          always-auth=true
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Verify NPM Authentication
-        run: |
-          NPM_USER=$(npm whoami)
-          echo "Authenticated as: $NPM_USER"
+          npm config set //registry.npmjs.org/:_authToken \${NPM_TOKEN} \
+            --location=project
 
       - name: Publish to NPM
         run: |
@@ -55,7 +45,3 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
-
-      - name: Clean up NPM config
-        if: always()
-        run: rm -f .npmrc

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,8 +17,8 @@ jobs:
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you
             for your contributions.
-          stale-pr-label: 'wontfix'
-          exempt-pr-labels: 'long-term'
+          stale-pr-label: wontfix
+          exempt-pr-labels: long-term
           days-before-pr-stale: 90
           days-before-pr-close: 14
           repo-token: ${{ secrets.STALE_WORKFLOW_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Use Node.js
         uses: zendesk/setup-node@v4
         with:
-          node-version: "${{ matrix.node-version }}"
-          cache: "yarn"
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
       - uses: zendesk/cache@v3
         with:
           path: |

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v20.17.0
+.node-version


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`73e8649`](https://github.com/zendesk/zcli/pull/366/commits/73e8649c9ca162908849c16753b2c92620ae3f87) Replace `.nvmrc` with a symlink to `.node-version`



### [`6ace3a0`](https://github.com/zendesk/zcli/pull/366/commits/6ace3a0d008a38bcc18ccfc64ea57e7b3fc9e515) Remove unnecessary string quotes from Github Action yml files



### [`6d95bbb`](https://github.com/zendesk/zcli/pull/366/commits/6d95bbb8360be1cc3f81b8dd84877b4439532697) Remove deprecated option from `lerna publish`

The `--no-verify-access` option has been deprecated[^1] was causing the
following warning:

> lerna WARN verify-access --verify-access=false and --no-verify-access are
> no longer needed, because the legacy preemptive access verification is now
> disabled by default. Requests will fail with appropriate errors when not
> authorized correctly.

[^1]: https://github.com/lerna/lerna/tree/v5.6.2/commands/publish#--no-verify-access


### [`57c1b68`](https://github.com/zendesk/zcli/pull/366/commits/57c1b6855288f2f76fe40bb53e88fa846072347d) Simplify NPM publish

- Use `npm config set` to configure auth token.
- Use env var in `.npmrc` file instead of the actual token.
- Remove step to check authenticated user.


### [`39dd8ff`](https://github.com/zendesk/zcli/pull/366/commits/39dd8ff41478d9b8c6b6c9b0d9a86d19e7fa3956) Hide yarn run command to not expose the TOTP value



<!-- === GH HISTORY FENCE === -->

## Detail
- https://zendesk.atlassian.net/browse/APPS-8211

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
