### PR TITLE
fix(getBrandId): parameterize text prompt

### DIFF
--- a/packages/zcli-themes/src/commands/themes/import.ts
+++ b/packages/zcli-themes/src/commands/themes/import.ts
@@ -31,7 +31,7 @@ export default class Import extends Command {
     let { flags: { brandId }, argv: [themeDirectory] } = await this.parse(Import)
     const themePath = path.resolve(themeDirectory)
 
-    brandId = brandId || await getBrandId()
+    brandId = brandId || await getBrandId('What brand should the theme be imported to?')
 
     const job = await createThemeImportJob(brandId)
     const { file, removePackage } = await createThemePackage(themePath)

--- a/packages/zcli-themes/src/commands/themes/list.ts
+++ b/packages/zcli-themes/src/commands/themes/list.ts
@@ -23,7 +23,7 @@ export default class List extends Command {
   async run () {
     let { flags: { brandId } } = await this.parse(List)
 
-    brandId = brandId || await getBrandId()
+    brandId = brandId || await getBrandId('What brand should the themes be listed for?')
 
     try {
       CliUx.ux.action.start('Listing themes')

--- a/packages/zcli-themes/src/lib/getBrandId.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.ts
@@ -3,7 +3,7 @@ import type { Brand } from '../types'
 import { request } from '@zendesk/zcli-core'
 import * as inquirer from 'inquirer'
 
-export default async function getBrandId (): Promise<string> {
+export default async function getBrandId (message: string): Promise<string> {
   try {
     const { data: { brands } } = await request.requestAPI('/api/v2/brands.json', {
       validateStatus: (status: number) => status === 200
@@ -16,7 +16,7 @@ export default async function getBrandId (): Promise<string> {
     const { brandId } = await inquirer.prompt({
       type: 'list',
       name: 'brandId',
-      message: 'What brand should the theme be imported to?',
+      message : message || 'Choose a brand',
       choices: brands.map((brand: Brand) => ({
         name: brand.name,
         value: brand.id.toString()

--- a/packages/zcli-themes/src/lib/getBrandId.ts
+++ b/packages/zcli-themes/src/lib/getBrandId.ts
@@ -3,7 +3,7 @@ import type { Brand } from '../types'
 import { request } from '@zendesk/zcli-core'
 import * as inquirer from 'inquirer'
 
-export default async function getBrandId (message: string): Promise<string> {
+export default async function getBrandId (message?: string): Promise<string> {
   try {
     const { data: { brands } } = await request.requestAPI('/api/v2/brands.json', {
       validateStatus: (status: number) => status === 200
@@ -16,7 +16,7 @@ export default async function getBrandId (message: string): Promise<string> {
     const { brandId } = await inquirer.prompt({
       type: 'list',
       name: 'brandId',
-      message : message || 'Choose a brand',
+      message: message ?? 'Choose a brand',
       choices: brands.map((brand: Brand) => ({
         name: brand.name,
         value: brand.id.toString()


### PR DESCRIPTION
## Description

Parameterize `getBrandId()` so the the text prompt for `themes:list` and `themes:import` match how they are used.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Do NOT write here! This section will be filled in by GitHub Action
automatically. If you don't want this, either remove the markers or write
outside the fences.
<!-- === GH HISTORY FENCE === -->

## Detail

<img width="446" height="36" alt="image" src="https://github.com/user-attachments/assets/cc381e47-e2fa-4342-9eb3-35680092a4fb" />

closes https://github.com/zendesk/zcli/issues/367

## Checklist
