### PR TITLE
chore(deps): pin axios to 1.8.4 to unblock CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             node-modules-${{ runner.os }}-${{ hashFiles('**/package.json') }}-
             node-modules-${{ runner.os }}-
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test
       - run: yarn test:functional

--- a/packages/zcli-apps/package.json
+++ b/packages/zcli-apps/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "adm-zip": "0.5.10",
     "archiver": "^5.3.1",
-    "axios": "^1.7.5",
+    "axios": "1.8.4",
     "chalk": "^4.1.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/packages/zcli-connectors/package.json
+++ b/packages/zcli-connectors/package.json
@@ -23,7 +23,7 @@
     "@rollup/plugin-node-resolve": "^15.0.0",
     "adm-zip": "0.5.10",
     "archiver": "^5.3.1",
-    "axios": "^1.7.5",
+    "axios": "1.8.4",
     "chalk": "^4.1.2",
     "fs-extra": "^10.0.0",
     "rimraf": "^3.0.2",

--- a/packages/zcli-core/package.json
+++ b/packages/zcli-core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@oclif/plugin-plugins": "=2.1.12",
-    "axios": "^1.7.5",
+    "axios": "1.8.4",
     "chalk": "^4.1.2",
     "fs-extra": "^10.1.0"
   },

--- a/packages/zcli-themes/package.json
+++ b/packages/zcli-themes/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/inquirer": "^8.0.0",
     "@types/ws": "^8.5.4",
-    "axios": "^1.7.5",
+    "axios": "1.8.4",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,7 +3392,7 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-axios@^1.0.0, axios@^1.7.5:
+axios@1.8.4, axios@^1.0.0:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
   integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==


### PR DESCRIPTION
#### Description
All PRs cut after 2026-05-01 have red CI in `zcli-core/src/lib/auth.test.ts`. Root cause: `lerna bootstrap` re-resolves `axios: ^1.7.5` inside each package and overwrites the root `node_modules/axios` away from the locked `1.8.4`. Recent axios releases changed the fetch adapter's error-path handling, breaking the existing test stubs.

Pinning axios to an exact `1.8.4` removes the drift. `1.8.4` is also the first version with the fix for CVE-2025-27152 (affects `<1.8.2`). Adding `--frozen-lockfile` to CI's `yarn install` makes any future resolver drift a hard CI failure instead of a silent one.

**Timeline**
- **2024-09-05** — PR #253 lands with `axios: ^1.7.5` and switches to axios' fetch adapter. The caret range makes resolution time-dependent.
- **2025-03-19** — axios 1.8.4 published. Lockfile pins to this; CI + cache keep it stable.
- **2026-05-01** — last green master CI run, still resolving to 1.8.4.
- **2026-05-02** — axios 1.16.0 published and tagged `latest`. The fetch adapter's error path now touches `response.body`, which the `auth.test.ts` stubs don't provide.
- **2026-05-07** — first PR to hit the new resolution (#369). `yarn install` → lerna bootstrap → drift → 4 failures in `auth.test.ts`. Every PR opened from now on is red until master is fixed.

#### References
N/A

#### Risks
Low. `1.8.4` is what master's last green CI resolved to. Unblocks #369 and every other PR.