### PR TITLE
chore(deps): bump axios to ^1.12.0 and refresh fetch-adapter test stubs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             node-modules-${{ runner.os }}-${{ hashFiles('**/package.json') }}-
             node-modules-${{ runner.os }}-
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn test
       - run: yarn test:functional

--- a/packages/zcli-apps/package.json
+++ b/packages/zcli-apps/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "adm-zip": "0.5.10",
     "archiver": "^5.3.1",
-    "axios": "^1.7.5",
+    "axios": "1.16.0",
     "chalk": "^4.1.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/packages/zcli-apps/package.json
+++ b/packages/zcli-apps/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "adm-zip": "0.5.10",
     "archiver": "^5.3.1",
-    "axios": "1.16.0",
+    "axios": "^1.12.0",
     "chalk": "^4.1.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/packages/zcli-connectors/package.json
+++ b/packages/zcli-connectors/package.json
@@ -23,7 +23,7 @@
     "@rollup/plugin-node-resolve": "^15.0.0",
     "adm-zip": "0.5.10",
     "archiver": "^5.3.1",
-    "axios": "1.16.0",
+    "axios": "^1.12.0",
     "chalk": "^4.1.2",
     "fs-extra": "^10.0.0",
     "rimraf": "^3.0.2",

--- a/packages/zcli-connectors/package.json
+++ b/packages/zcli-connectors/package.json
@@ -23,7 +23,7 @@
     "@rollup/plugin-node-resolve": "^15.0.0",
     "adm-zip": "0.5.10",
     "archiver": "^5.3.1",
-    "axios": "^1.7.5",
+    "axios": "1.16.0",
     "chalk": "^4.1.2",
     "fs-extra": "^10.0.0",
     "rimraf": "^3.0.2",

--- a/packages/zcli-core/package.json
+++ b/packages/zcli-core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@oclif/plugin-plugins": "=2.1.12",
-    "axios": "1.16.0",
+    "axios": "^1.12.0",
     "chalk": "^4.1.2",
     "fs-extra": "^10.1.0"
   },

--- a/packages/zcli-core/package.json
+++ b/packages/zcli-core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@oclif/plugin-plugins": "=2.1.12",
-    "axios": "^1.7.5",
+    "axios": "1.16.0",
     "chalk": "^4.1.2",
     "fs-extra": "^10.1.0"
   },

--- a/packages/zcli-core/src/lib/auth.test.ts
+++ b/packages/zcli-core/src/lib/auth.test.ts
@@ -93,14 +93,11 @@ describe('Auth', () => {
         promptStub.onFirstCall().resolves('z3ntest')
         promptStub.onSecondCall().resolves('test@zendesk.com')
         promptStub.onThirdCall().resolves('123456')
-        fetchStub.withArgs(sinon.match({
-          method: 'GET',
-          url: 'https://z3ntest.zendesk.com/api/v2/account/settings.json',
-          headers: new Headers({
-            Accept: 'application/json, text/plain, */*',
-            Authorization: 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
-          })
-        }))
+        fetchStub.withArgs(sinon.match((req: Request) =>
+          req.method === 'GET' &&
+          req.url === 'https://z3ntest.zendesk.com/api/v2/account/settings.json' &&
+          req.headers.get('Authorization') === 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
+        ))
           .resolves({
             status: 200,
             ok: true,
@@ -120,14 +117,11 @@ describe('Auth', () => {
         promptStub.onFirstCall().resolves('z3ntest')
         promptStub.onSecondCall().resolves('test@zendesk.com')
         promptStub.onThirdCall().resolves('123456')
-        fetchStub.withArgs(sinon.match({
-          method: 'GET',
-          url: 'https://z3ntest.example.com/api/v2/account/settings.json',
-          headers: new Headers({
-            Accept: 'application/json, text/plain, */*',
-            Authorization: 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
-          })
-        }))
+        fetchStub.withArgs(sinon.match((req: Request) =>
+          req.method === 'GET' &&
+          req.url === 'https://z3ntest.example.com/api/v2/account/settings.json' &&
+          req.headers.get('Authorization') === 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
+        ))
           .resolves({
             status: 200,
             ok: true,
@@ -146,14 +140,11 @@ describe('Auth', () => {
         promptStub.reset()
         promptStub.onFirstCall().resolves('test@zendesk.com')
         promptStub.onSecondCall().resolves('123456')
-        fetchStub.withArgs(sinon.match({
-          method: 'GET',
-          url: 'https://z3ntest.example.com/api/v2/account/settings.json',
-          headers: new Headers({
-            Accept: 'application/json, text/plain, */*',
-            Authorization: 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
-          })
-        }))
+        fetchStub.withArgs(sinon.match((req: Request) =>
+          req.method === 'GET' &&
+          req.url === 'https://z3ntest.example.com/api/v2/account/settings.json' &&
+          req.headers.get('Authorization') === 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
+        ))
           .resolves({
             status: 200,
             ok: true,
@@ -173,14 +164,11 @@ describe('Auth', () => {
         promptStub.onFirstCall().resolves('z3ntest')
         promptStub.onSecondCall().resolves('test@zendesk.com')
         promptStub.onThirdCall().resolves('123456')
-        fetchStub.withArgs(sinon.match({
-          method: 'GET',
-          url: 'https://z3ntest.zendesk.com/api/v2/account/settings.json',
-          headers: new Headers({
-            Accept: 'application/json, text/plain, */*',
-            Authorization: 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
-          })
-        }))
+        fetchStub.withArgs(sinon.match((req: Request) =>
+          req.method === 'GET' &&
+          req.url === 'https://z3ntest.zendesk.com/api/v2/account/settings.json' &&
+          req.headers.get('Authorization') === 'Basic dGVzdEB6ZW5kZXNrLmNvbS90b2tlbjoxMjM0NTY='
+        ))
           .resolves({
             status: 403,
             ok: false,

--- a/packages/zcli-themes/package.json
+++ b/packages/zcli-themes/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/inquirer": "^8.0.0",
     "@types/ws": "^8.5.4",
-    "axios": "^1.7.5",
+    "axios": "1.16.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
     "cors": "^2.8.5",

--- a/packages/zcli-themes/package.json
+++ b/packages/zcli-themes/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/inquirer": "^8.0.0",
     "@types/ws": "^8.5.4",
-    "axios": "1.16.0",
+    "axios": "^1.12.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
     "cors": "^2.8.5",

--- a/packages/zcli-themes/tests/functional/import.test.ts
+++ b/packages/zcli-themes/tests/functional/import.test.ts
@@ -58,6 +58,7 @@ describe('themes:import', function () {
         })).resolves({
           status: 200,
           ok: true,
+          headers: new Headers(),
           text: () => Promise.resolve('')
         })
       })
@@ -155,6 +156,7 @@ describe('themes:import', function () {
         })).resolves({
           status: 200,
           ok: true,
+          headers: new Headers(),
           text: () => Promise.resolve('')
         })
       })

--- a/packages/zcli-themes/tests/functional/update.test.ts
+++ b/packages/zcli-themes/tests/functional/update.test.ts
@@ -54,6 +54,7 @@ describe('themes:update', function () {
         })).resolves({
           status: 200,
           ok: true,
+          headers: new Headers(),
           text: () => Promise.resolve('')
         })
       })
@@ -147,6 +148,7 @@ describe('themes:update', function () {
         })).resolves({
           status: 200,
           ok: true,
+          headers: new Headers(),
           text: () => Promise.resolve('')
         })
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,7 +3392,16 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-axios@^1.0.0, axios@^1.7.5:
+axios@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
+
+axios@^1.0.0:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
   integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
@@ -5244,6 +5253,11 @@ follow-redirects@^1.15.6:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
+
 foreground-child@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
@@ -5264,6 +5278,17 @@ form-data@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -8041,6 +8066,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pump@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,7 +3392,7 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-axios@1.16.0:
+axios@^1.0.0, axios@^1.12.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
   integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
@@ -3400,15 +3400,6 @@ axios@1.16.0:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
-
-axios@^1.0.0:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
-  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 babel-plugin-polyfill-corejs2@^0.4.15:
   version "0.4.17"
@@ -5247,11 +5238,6 @@ flatted@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
   integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
-
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 follow-redirects@^1.16.0:
   version "1.16.0"
@@ -8061,11 +8047,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 proxy-from-env@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
#### Description
Alternative to #370. Users installing zcli today already get axios `1.16.0` via the `^1.7.5` range, so CI should validate what users actually run rather than pinning to the old `1.8.4`. 1.16.0 also patches CVE-2025-58754 (affects `<1.12.0`) and CVE-2025-27152 (`<1.8.2`).

Trade-off vs #370: fixes test stubs against the newer fetch adapter rather than keeping old stubs working against an older axios. Same effective unblock; healthier long-term posture.

#### References
- Blocks: #369
- Alternative to: #370

#### Risks
Low. `1.16.0` is what `yarn install` on master already resolves to today. Test stub changes are internal-only.
