### PR TITLE
fix(connectors): [VEG-4002] - resolve Windows Vite "Entry module cannot be external"

### DIFF
--- a/packages/zcli-connectors/src/lib/vite/vite-config.test.ts
+++ b/packages/zcli-connectors/src/lib/vite/vite-config.test.ts
@@ -246,6 +246,48 @@ describe('ViteConfigBuilder', () => {
     })
   })
 
+  describe('external function', () => {
+    const getExternal = () =>
+      ViteConfigBuilder.createConfig({
+        inputPath: '/input',
+        outputPath: '/output'
+      }).build.rollupOptions.external
+
+    it('should bundle relative imports', () => {
+      const external = getExternal()
+      expect(external('./foo')).to.be.false
+      expect(external('../foo/bar')).to.be.false
+    })
+
+    it('should bundle posix absolute paths', () => {
+      const external = getExternal()
+      expect(external('/Users/dev/project/src/index.ts')).to.be.false
+    })
+
+    // Rollup normalizes ids to forward slashes even on Windows, so the entry
+    // arrives as e.g. C:/.../src/index.ts. isAbsolute (win32) must classify it
+    // as local so it is bundled, not treated as external. Regression for the
+    // "Entry module ... cannot be external" Windows bundle failure.
+    const winIt = process.platform === 'win32' ? it : it.skip
+    winIt('should bundle windows absolute paths (forward-slash normalized)', () => {
+      const external = getExternal()
+      expect(external('C:/Users/dev/project/src/index.ts')).to.be.false
+      expect(external('C:\\Users\\dev\\project\\src\\index.ts')).to.be.false
+    })
+
+    it('should treat bare module specifiers as external', () => {
+      const external = getExternal()
+      expect(external('lodash')).to.be.true
+      expect(external('lodash/get')).to.be.true
+    })
+
+    it('should always bundle @zendesk/connector-sdk', () => {
+      const external = getExternal()
+      expect(external('@zendesk/connector-sdk')).to.be.false
+      expect(external('@zendesk/connector-sdk/dist/index.js')).to.be.false
+    })
+  })
+
   describe('recursive directory copying', () => {
     it('should handle nested directories when copying to target directory', async () => {
       const outputPath = '/output'

--- a/packages/zcli-connectors/src/lib/vite/vite-config.ts
+++ b/packages/zcli-connectors/src/lib/vite/vite-config.ts
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import { existsSync, copyFileSync, mkdirSync, readdirSync, statSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join } from 'path'
 import { ManifestGenerator } from '../manifest-generator/generator'
 
 export interface ViteConfigOptions {
@@ -77,7 +77,7 @@ export class ViteConfigBuilder {
         return false
       }
 
-      return !id.startsWith('.') && !id.startsWith('/') && !id.includes('\\')
+      return !id.startsWith('.') && !isAbsolute(id)
     }
   }
 


### PR DESCRIPTION
## Description

Fixes a Windows-only failure when running `zcli connectors bundle`:

```
Vite build failed: Entry module "src/index.ts" cannot be external.
```

Rollup normalizes module IDs to forward slashes even on Windows, so the entry
arrives as `C:/.../src/index.ts`. The old external check
(`!id.startsWith('.') && !id.startsWith('/') && !id.includes('\\')`) matched
neither the drive-letter path (doesn't start with `/`) nor a backslash (already
normalized away), so the entry was flagged external and Vite refused to build.
macOS/Linux were unaffected because posix absolute paths start with `/`.

Replaced the manual `/` + `\\` checks with `path.isAbsolute`, which correctly
recognizes posix (`/...`) and Windows (`C:/`, `C:\`, UNC `\\`) absolute paths.
The `@zendesk/connector-sdk` special-case is unchanged.

<!-- === GH HISTORY FENCE === -->
### ac4c283999d6261c52e5eb1be5a09e817ab1c4cd fix(connectors): resolve Windows Vite "Entry module cannot be external"

Rollup normalizes module IDs to forward slashes even on Windows, so the
entry arrives as C:/.../src/index.ts. The old external check used
startsWith('/') and includes('\\'), neither of which match a drive-letter
path, so the entry was flagged external and Vite refused to build. Use
path.isAbsolute (cross-platform) instead.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- === GH HISTORY FENCE === -->

## Detail

`packages/zcli-connectors/src/lib/vite/vite-config.ts` — `createExternalFunction`:

```js
// before
return !id.startsWith('.') && !id.startsWith('/') && !id.includes('\\')
// after
return !id.startsWith('.') && !isAbsolute(id)
```

Added an `external function` test suite covering relative imports, posix absolute
paths, bare module specifiers, `@zendesk/connector-sdk`, and a win32-only
regression test (skipped off-Windows) asserting `C:/...` and `C:\...` entries are
bundled.

## Checklist

- [x] :guardsman: includes new unit and functional tests
