### PR TITLE
test(connectors): [VEG-4002] - add e2e bundle test to reproduce Windows entry-external bug

### DIFF
--- a/packages/zcli-connectors/src/lib/vite/vite-config.test.ts
+++ b/packages/zcli-connectors/src/lib/vite/vite-config.test.ts
@@ -246,6 +246,48 @@ describe('ViteConfigBuilder', () => {
     })
   })
 
+  describe('external function', () => {
+    const getExternal = () =>
+      ViteConfigBuilder.createConfig({
+        inputPath: '/input',
+        outputPath: '/output'
+      }).build.rollupOptions.external
+
+    it('should bundle relative imports', () => {
+      const external = getExternal()
+      expect(external('./foo')).to.be.false
+      expect(external('../foo/bar')).to.be.false
+    })
+
+    it('should bundle posix absolute paths', () => {
+      const external = getExternal()
+      expect(external('/Users/dev/project/src/index.ts')).to.be.false
+    })
+
+    // Rollup normalizes ids to forward slashes even on Windows, so the entry
+    // arrives as e.g. C:/.../src/index.ts. isAbsolute (win32) must classify it
+    // as local so it is bundled, not treated as external. Regression for the
+    // "Entry module ... cannot be external" Windows bundle failure.
+    const winIt = process.platform === 'win32' ? it : it.skip
+    winIt('should bundle windows absolute paths (forward-slash normalized)', () => {
+      const external = getExternal()
+      expect(external('C:/Users/dev/project/src/index.ts')).to.be.false
+      expect(external('C:\\Users\\dev\\project\\src\\index.ts')).to.be.false
+    })
+
+    it('should treat bare module specifiers as external', () => {
+      const external = getExternal()
+      expect(external('lodash')).to.be.true
+      expect(external('lodash/get')).to.be.true
+    })
+
+    it('should always bundle @zendesk/connector-sdk', () => {
+      const external = getExternal()
+      expect(external('@zendesk/connector-sdk')).to.be.false
+      expect(external('@zendesk/connector-sdk/dist/index.js')).to.be.false
+    })
+  })
+
   describe('recursive directory copying', () => {
     it('should handle nested directories when copying to target directory', async () => {
       const outputPath = '/output'

--- a/packages/zcli-connectors/src/lib/vite/vite-config.ts
+++ b/packages/zcli-connectors/src/lib/vite/vite-config.ts
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import { existsSync, copyFileSync, mkdirSync, readdirSync, statSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join } from 'path'
 import { ManifestGenerator } from '../manifest-generator/generator'
 
 export interface ViteConfigOptions {
@@ -77,7 +77,7 @@ export class ViteConfigBuilder {
         return false
       }
 
-      return !id.startsWith('.') && !id.startsWith('/') && !id.includes('\\')
+      return !id.startsWith('.') && !isAbsolute(id)
     }
   }
 

--- a/packages/zcli-connectors/tests/functional/bundle-e2e.test.ts
+++ b/packages/zcli-connectors/tests/functional/bundle-e2e.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import { join } from 'path'
+import { createConnectorViteConfig, ViteRunner } from '../../src/lib/vite'
+
+/**
+ * End-to-end bundle test that drives a REAL Vite/Rollup build (nothing stubbed).
+ * This exercises the actual `external` function against a real, absolute entry
+ * path — the code path that CI's mocked bundle test never reaches.
+ *
+ * On Windows the entry resolves to a drive-letter path (e.g.
+ * C:/.../src/index.ts). Rollup normalizes ids to forward slashes, so a buggy
+ * `external` check that only recognizes posix absolute paths ("/") flags the
+ * entry as external and the build fails with:
+ *   "Entry module ... cannot be external."
+ *
+ * The fixture is the simplest possible connector: a default-export object of
+ * the same shape `@zendesk/connector-sdk`'s manifest() returns (name/title/
+ * description are the fields ManifestGenerator requires). Keeping it dependency
+ * free means the build only tests the entry path, which is where the bug lives.
+ */
+describe('bundle (e2e real vite build)', function () {
+  // A real Vite build is far slower than the default mocha timeout.
+  this.timeout(120000)
+
+  let connectorDir: string
+  let distDir: string
+
+  beforeEach(() => {
+    // realpathSync canonicalizes symlinked temp roots (e.g. macOS /var ->
+    // /private/var) so ManifestGenerator's realpath security check passes.
+    connectorDir = fs.realpathSync(fs.mkdtempSync(join(os.tmpdir(), 'zcli-connectors-e2e-')))
+    distDir = join(connectorDir, 'dist')
+
+    const srcDir = join(connectorDir, 'src')
+    fs.mkdirSync(srcDir, { recursive: true })
+
+    // Type-free source: valid as both JS and TS, no external dependencies.
+    const indexContents = [
+      'const connector = {',
+      "  name: 'e2e-fixture',",
+      "  title: 'E2E Fixture',",
+      "  description: 'E2E bundle test connector',",
+      "  version: '1.0.0'",
+      '}',
+      '',
+      'export default connector',
+      ''
+    ].join('\n')
+
+    fs.writeFileSync(join(srcDir, 'index.ts'), indexContents, 'utf-8')
+  })
+
+  afterEach(() => {
+    fs.rmSync(connectorDir, { recursive: true, force: true })
+  })
+
+  it('bundles a connector without treating the entry as external', async () => {
+    const config = createConnectorViteConfig({
+      inputPath: connectorDir,
+      outputPath: distDir
+    })
+
+    const result = await ViteRunner.run(config)
+
+    // On the Windows bug this is true, with an
+    // "Entry module ... cannot be external" error.
+    expect(result.hasErrors(), JSON.stringify(result.toJson().errors)).to.be.false
+    expect(fs.existsSync(join(distDir, 'connector.js'))).to.be.true
+    expect(fs.existsSync(join(distDir, 'manifest.json'))).to.be.true
+  })
+})

--- a/packages/zcli-connectors/tests/functional/bundle-e2e.test.ts
+++ b/packages/zcli-connectors/tests/functional/bundle-e2e.test.ts
@@ -26,8 +26,8 @@ describe('bundle (e2e real vite build)', function () {
   // A real Vite build is far slower than the default mocha timeout.
   this.timeout(120000)
 
-  let connectorDir: string
-  let distDir: string
+  let connectorDir = ''
+  let distDir = ''
 
   beforeEach(() => {
     // realpathSync canonicalizes symlinked temp roots (e.g. macOS /var ->
@@ -55,7 +55,11 @@ describe('bundle (e2e real vite build)', function () {
   })
 
   afterEach(() => {
-    fs.rmSync(connectorDir, { recursive: true, force: true })
+    // beforeEach may have failed before connectorDir was assigned; guard so
+    // cleanup never throws on an empty path.
+    if (connectorDir) {
+      fs.rmSync(connectorDir, { recursive: true, force: true })
+    }
   })
 
   it('bundles a connector without treating the entry as external', async () => {


### PR DESCRIPTION
## Description

Fixes the Windows-only bundle failure and adds a real end-to-end bundle test
that reproduces it.

### The bug

Rollup normalizes module IDs to forward slashes even on Windows, so the entry
arrives as `C:/.../src/index.ts`. The old `external` check used
`startsWith('/')` and `includes('\\')`, neither of which match a drive-letter
path, so the entry was flagged external and Vite refused to build with:
`Entry module "src/index.ts" cannot be external.` The fix uses
`path.isAbsolute` (cross-platform).

### The test

The existing `tests/functional/bundle.test.ts` stubs both
`ViteConfigBuilder.createConfig` and `ViteRunner.run`, so the real `external`
function and Rollup build never execute in CI. That's why the failure went
undetected even though `windows-latest` is in the test matrix.

This new test drives an **un-stubbed** Vite/Rollup build over a minimal,
dependency-free connector fixture, exercising the actual absolute entry-path
classification. It passes on ubuntu/macos, and reproduces the Windows failure
without the `external` fix.

<!-- === GH HISTORY FENCE === -->
### b39cb6f73ceb30ec03ef0adb885db32c09842e16 test(connectors): add e2e bundle test to reproduce Windows entry-external bug

The existing functional bundle test stubs ViteConfigBuilder.createConfig and
ViteRunner.run, so the real `external` function and Rollup build never run in
CI — which is why the Windows-only "Entry module cannot be external" failure
went undetected despite windows-latest being in the test matrix.

This test drives a real Vite/Rollup build over a minimal dependency-free
connector fixture, exercising the actual entry-path classification. It passes
on posix and is expected to fail on Windows until the `external` fix lands.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


### 418a1dc214376f6ff9e51a67bcd2d87d1d49e9b1 fix(connectors): resolve Windows Vite "Entry module cannot be external"

Rollup normalizes module IDs to forward slashes even on Windows, so the
entry arrives as C:/.../src/index.ts. The old external check used
startsWith('/') and includes('\\'), neither of which match a drive-letter
path, so the entry was flagged external and Vite refused to build. Use
path.isAbsolute (cross-platform) instead.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


### 468c87ecd407fbd6f91cc42362fb8f8026f204ab test(connectors): guard e2e bundle cleanup against failed setup

Mocha runs afterEach even when beforeEach throws. Initialize connectorDir
to an empty string and guard rmSync so cleanup never throws on an unset path.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- === GH HISTORY FENCE === -->

## Detail

Fixture mirrors what \`@zendesk/connector-sdk\`'s \`manifest()\` returns — a
default-export object with \`name\`/\`title\`/\`description\` (the fields
\`ManifestGenerator\` requires) — kept dependency-free so only the entry path is
under test.

## Checklist

- [x] :guardsman: includes new unit and functional tests
