### PR TITLE
chore(cicd): setup trusted publishing to npm

### DIFF
--- a/.github/workflows/npm-trusted-publication.yml
+++ b/.github/workflows/npm-trusted-publication.yml
@@ -1,0 +1,28 @@
+name: npm trusted publishing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bootstrap:
+    strategy:
+      matrix:
+        include:
+          - package-name: '@zendesk/zcli'
+            package-json-file-path: packages/zcli/package.json
+          - package-name: '@zendesk/zcli-apps'
+            package-json-file-path: packages/zcli-apps/package.json
+          - package-name: '@zendesk/zcli-connectors'
+            package-json-file-path: packages/zcli-connectors/package.json
+          - package-name: '@zendesk/zcli-core'
+            package-json-file-path: packages/zcli-core/package.json
+          - package-name: '@zendesk/zcli-themes'
+            package-json-file-path: packages/zcli-themes/package.json
+    uses: zendesk/gw/.github/workflows/npm-trusted-publication.yml@main
+    secrets: inherit
+    with:
+      package-name: ${{ matrix.package-name }}
+      package-json-file-path: ${{ matrix.package-json-file-path }}
+      publish-workflow: publish.yml
+      repository: ${{ github.repository }}
+      github-environment: npm-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,35 +13,20 @@ jobs:
     name: Build and Publish to NPM
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC trusted publishing
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: .node-version
+          node-version: 22 # >= 22.14.0 is required for OIDC trusted publishing
           cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Install oathtool for 2FA
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes oathtool
-
-      - name: Configure NPM Authentication
-        run: |
-          npm config set //registry.npmjs.org/:_authToken \${NPM_TOKEN} \
-            --location=project
-
       - name: Publish to NPM
-        run: |
-          TOTP=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
-
-          yarn --silent lerna publish from-package \
-            --yes \
-            --otp $TOTP
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+        run: yarn lerna publish from-package --yes


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Setup trusted publishing to npm.

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`7e054eb`](https://github.com/zendesk/zcli/pull/386/commits/7e054eb370721bb0cc1ad3612c641a8d002ef8be) Setup trusted publishing to npm



<!-- === GH HISTORY FENCE === -->

## Detail

https://zendesk.atlassian.net/browse/APPS-8347

## Checklist

- [ ] :guardsman: includes new unit and functional tests
