### PR TITLE
chore(ci/cd): fix OIDC publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "repository": "zendesk/zcli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/zcli.git"
+  },
   "types": "lib/index.d.ts",
   "resolutions": {
     "@types/glob": "^8.1.0"

--- a/packages/zcli-apps/package.json
+++ b/packages/zcli-apps/package.json
@@ -4,6 +4,10 @@
   "version": "1.1.3",
   "author": "@wattle",
   "npmRegistry": "https://registry.npmjs.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/zcli.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/zcli-connectors/package.json
+++ b/packages/zcli-connectors/package.json
@@ -4,6 +4,10 @@
   "version": "1.1.3",
   "author": "@vegemite",
   "npmRegistry": "https://registry.npmjs.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/zcli.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/zcli-core/package.json
+++ b/packages/zcli-core/package.json
@@ -4,6 +4,10 @@
   "description": "ZCLI core libraries and services",
   "main": "src/index.ts",
   "npmRegistry": "https://registry.npmjs.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/zcli.git"
+  },
   "keywords": [
     "zcli",
     "zendesk",

--- a/packages/zcli-themes/package.json
+++ b/packages/zcli-themes/package.json
@@ -4,6 +4,10 @@
   "version": "1.1.3",
   "author": "@zendesk/vikings",
   "npmRegistry": "https://registry.npmjs.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/zcli.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/zcli/package.json
+++ b/packages/zcli/package.json
@@ -4,6 +4,10 @@
   "version": "1.1.3",
   "author": "@wattle",
   "npmRegistry": "https://registry.npmjs.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zendesk/zcli.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description
Fix OIDC publishing by adding the missing `repository.url` field to packages `package.json` file.

Error from https://github.com/zendesk/zcli/actions/runs/29713997613/job/88263232182#step:5:78
```
lerna WARN notice Package failed to publish: @zendesk/zcli-connectors
lerna ERR! E422 Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/zendesk/zcli" from provenance
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
lerna WARN notice Package failed to publish: @zendesk/zcli-apps
lerna ERR! E422 Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/zendesk/zcli" from provenance
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
lerna WARN notice Package failed to publish: @zendesk/zcli-themes
lerna ERR! E422 Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/zendesk/zcli" from provenance
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
error Command failed with exit code 1.
```

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`ef4275c`](https://github.com/zendesk/zcli/pull/388/commits/ef4275c58997d18ad984dbb89a0d3a8321ef8c6f) Set `repository` field using object format in package.json

From npm Docs[^1]:

> **Note on normalization**: When you publish a package, npm normalizes the
> repository field to the full object format with a url property. If you use a
> shorthand format (like "npm/example"), you'll see a warning during npm publish
> indicating that the field was auto-corrected. While the shorthand format
> currently works, it's recommended to use the full object format in your
> package.json to avoid warnings and ensure future compatibility:
>
> ```json
> {
>   "repository": {
>     "type": "git",
>     "url": "git+https://github.com/npm/example.git"
>   }
> }
> ```

[^1]: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository


### [`b7d2ccb`](https://github.com/zendesk/zcli/pull/388/commits/b7d2ccba96c9a769b0da59ec949a0d7bb4edda1c) Set `repository` field in packages `package.json`

`repository.url` is required to publish to npm using OIDC trusted publishing[^1].

> To publish from GitHub, your package's repository.url field in package.json
> must exactly match your GitHub repository. This may be an issue for
> misconfigured packages, but could also impact publication from forks that
> haven't updated package.json to match the forked repo.

[^1]: https://docs.npmjs.com/trusted-publishers#troubleshooting


<!-- === GH HISTORY FENCE === -->

## Detail

- https://zendesk.atlassian.net/browse/APPS-8347

## Checklist

- [ ] :guardsman: includes new unit and functional tests
