### PR TITLE
Document themes:migrate command

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -9,6 +9,7 @@ zcli themes commands helps with managing Zendesk Help Center theming workflow.
 * [`zcli themes:publish`](#zcli-themespublish)
 * [`zcli themes:delete`](#zcli-themesdelete)
 * [`zcli themes:list`](#zcli-themeslist)
+* [`zcli themes:migrate [THEMEDIRECTORY]`](#zcli-themesmigrate-themedirectory)
 
 ## Configuration
 
@@ -147,3 +148,20 @@ EXAMPLES
   $ zcli themes:list --brandId=123456
   $ zcli themes:list --brandId=123456 --json
 ```
+
+## `zcli themes:migrate [THEMEDIRECTORY]`
+
+migrate a theme to the latest supported version of the templating api
+
+```
+USAGE
+  $ zcli themes:migrate [THEMEDIRECTORY]
+
+ARGUMENTS
+  THEMEDIRECTORY  [default: .] theme path where manifest.json exists
+
+EXAMPLES
+  $ zcli themes:migrate ./copenhagen_theme
+```
+
+The command rewrites the theme files in place, so run it from within version control to review and revert the changes if needed. After migrating, preview the result locally with `zcli themes:preview`.

--- a/packages/zcli-themes/src/commands/themes/migrate.ts
+++ b/packages/zcli-themes/src/commands/themes/migrate.ts
@@ -9,8 +9,6 @@ import handleThemeMigrationApiError from '../../lib/handleThemeMigrationApiError
 export default class Migrate extends Command {
   static description = 'migrate theme to the latest version of the templating api'
 
-  static hidden = true
-
   static args = [
     { name: 'themeDirectory', required: true, default: '.' }
   ]


### PR DESCRIPTION
#### Description

The `themes:migrate` command has been available but hidden and undocumented while it was work in progress. It's now ready for a soft rollout: theme developers can use it to upgrade v1/v2 Help Center themes to Templating API v3. This unhides the command and documents it so customers can start using it and giving feedback.

#### Risks

Low — unhides an existing command and adds a docs entry. No behavior change to the command itself.
