### PR TITLE
chore(dependabot): add config for npm workspaces and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,140 @@
+version: 2
+
+registries:
+  npm-artifactory:
+    type: npm-registry
+    url: https://zdrepo.jfrog.io/zdrepo/api/npm/npm
+    username: ${{ secrets.ARTIFACTORY_USERNAME }}
+    password: ${{ secrets.ARTIFACTORY_API_KEY }}
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: weekly
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: deps
+      include: scope
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /packages/zcli
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: weekly
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: deps
+      include: scope
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /packages/zcli-apps
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: weekly
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: deps
+      include: scope
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /packages/zcli-connectors
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: weekly
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: deps
+      include: scope
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /packages/zcli-core
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: weekly
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: deps
+      include: scope
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /packages/zcli-themes
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: weekly
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: deps
+      include: scope
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      minor-and-patch-updates:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

Adds a `.github/dependabot.yml` covering `npm` for the root package and each of the five `packages/*` Lerna workspaces (via the Artifactory registry), plus `github-actions`. Weekly checks with minor/patch bumps grouped into a single PR per package. TypeScript majors are excluded since they require coordinated upgrades.

## Detail

One `package-ecosystem: npm` entry per directory (root, `packages/zcli`, `packages/zcli-apps`, `packages/zcli-connectors`, `packages/zcli-core`, `packages/zcli-themes`) so each sub-package's own dependencies are scanned independently.

JIRA: https://zendesk.atlassian.net/browse/APPS-8450

## Checklist

- [x] Config-only change — no new unit/functional tests needed
