### PR TITLE
Replace gihub token with service account token

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ZCLI_SVC_TOKEN }}
         run: |
           VERSION="${{ steps.version_bump.outputs.version }}"
 

--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -16,4 +16,4 @@ jobs:
           git fetch --depth 100
       - uses: zendesk/gh-ph@v1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ZCLI_SVC_TOKEN }}


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`f38ae76`](https://github.com/zendesk/zcli/pull/397/commits/f38ae76caecf1adf3008362d006896f095103ef1) Replace gihub token with service account token



<!-- === GH HISTORY FENCE === -->

## Detail

There’s a limitation on using GITHUB_TOKEN, it cannot trigger subsequent workflows/GHAs - https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs 

To resolve this issue, Created a new GitHub service account for ZCLI and configured GitHub Actions to use the token associated with that account.

Jira: https://zendesk.atlassian.net/browse/APPS-8200

## Checklist

- [ ] :guardsman: includes new unit and functional tests
