### PR TITLE
feat(themes): preview theme components with themes:preview

### DIFF
--- a/packages/zcli-themes/src/commands/themes/preview.ts
+++ b/packages/zcli-themes/src/commands/themes/preview.ts
@@ -10,17 +10,23 @@ import * as chalk from 'chalk'
 import * as cors from 'cors'
 import * as chokidar from 'chokidar'
 import preview from '../../lib/preview'
+import previewComponent from '../../lib/previewComponent'
+import getComponent from '../../lib/getComponent'
+import appendLivereloadSnippet from '../../lib/appendLivereloadSnippet'
 import getManifest from '../../lib/getManifest'
 import getVariables from '../../lib/getVariables'
 import getAssets from '../../lib/getAssets'
 import zass from '../../lib/zass'
+import { request } from '@zendesk/zcli-core'
+import type { Flags as PreviewFlags } from '../../types'
+import { getLocalServerBaseUrl } from '../../lib/getLocalServerBaseUrl'
 
 const logMiddleware = morgan((tokens, req, res) =>
   `${chalk.green(tokens.method(req, res))} ${tokens.url(req, res)} ${chalk.bold(tokens.status(req, res))}`
 )
 
 export default class Preview extends Command {
-  static description = 'preview a theme in development mode'
+  static description = 'preview a theme or theme component in development mode'
 
   static flags = {
     bind: Flags.string({ default: 'localhost', description: 'Bind theme server to a specific host' }),
@@ -32,36 +38,39 @@ export default class Preview extends Command {
   }
 
   static args = [
-    { name: 'themeDirectory', required: true, default: '.' }
+    { name: 'directory', required: true, default: '.' }
   ]
 
   static examples = [
-    '$ zcli themes:preview ./copenhagen_theme'
+    '$ zcli themes:preview ./copenhagen_theme',
+    '$ zcli themes:preview ./help-center-components/components/request-list'
   ]
 
   static strict = false
 
   async run () {
-    const { flags, argv: [themeDirectory] } = await this.parse(Preview)
-    const themePath = path.resolve(themeDirectory)
-    const { logs: tailLogs, bind: host, port, 'https-cert': httpsCert, 'https-key': httpsKey } = flags
+    const { flags, argv: [directory] } = await this.parse(Preview)
+    const targetPath = path.resolve(directory)
 
-    let httpsServerOptions: https.ServerOptions | null = null
-
-    if (httpsCert && httpsKey) {
-      httpsServerOptions = {
-        key: fs.readFileSync(httpsKey),
-        cert: fs.readFileSync(httpsCert)
-      }
+    if (!fs.existsSync(targetPath)) {
+      this.error(`Couldn't find a directory at path: "${targetPath}"`)
     }
 
-    const baseUrl = await preview(themePath, flags)
-    const app = express()
-    const server = httpsServerOptions === null ? http.createServer(app) : https.createServer(httpsServerOptions, app)
-    const wss = new WebSocket.Server({ server, path: '/livereload' })
+    const hasManifest = fs.existsSync(`${targetPath}/manifest.json`)
+    const hasComponent = fs.existsSync(`${targetPath}/component.json`)
 
-    app.use(cors())
-    tailLogs && app.use(logMiddleware)
+    if (hasManifest && hasComponent) {
+      this.error('Directory contains both manifest.json and component.json — preview the theme and the component from separate directories')
+    }
+
+    return hasComponent ? this.previewComponent(targetPath, flags) : this.previewTheme(targetPath, flags)
+  }
+
+  private async previewTheme (themePath: string, flags: PreviewFlags) {
+    const { logs: tailLogs } = flags
+
+    const baseUrl = await preview(themePath, flags)
+    const { app, server, wss } = this.createServer(flags)
 
     app.use('/guide/assets', express.static(`${themePath}/assets`))
     app.use('/guide/settings', express.static(`${themePath}/settings`))
@@ -84,11 +93,11 @@ export default class Preview extends Command {
       res.send(compiled)
     })
 
-    server.listen(port, host, async () => {
-      this.log(chalk.bold.green('Ready', chalk.blueBright(`${baseUrl}/hc/admin/local_preview/start`, '🚀')))
-      this.log(`You can exit preview mode in the UI or by visiting ${baseUrl}/hc/admin/local_preview/stop`)
-      tailLogs && this.log(chalk.bold('Tailing logs'))
-    })
+    await this.listen(server, wss, flags)
+
+    this.log(chalk.bold.green('Ready', chalk.blueBright(`${baseUrl}/hc/admin/local_preview/start`, '🚀')))
+    this.log(`You can exit preview mode in the UI or by visiting ${baseUrl}/hc/admin/local_preview/stop`)
+    tailLogs && this.log(chalk.bold('Tailing logs'))
 
     const monitoredPaths = [
       `${themePath}/assets`,
@@ -103,11 +112,7 @@ export default class Preview extends Command {
       this.log(chalk.bold('Change'), path)
       try {
         await preview(themePath, flags)
-        wss.clients.forEach((client) => {
-          if (client.readyState === WebSocket.OPEN) {
-            client.send('reload')
-          }
-        })
+        this.broadcastReload(wss)
       } catch (e) {
         this.error(e as Error, { exit: false })
       }
@@ -118,13 +123,190 @@ export default class Preview extends Command {
       .on('change', handleThemeChange)
       .on('unlink', handleThemeChange)
 
+    const close = () => {
+      // Stop watching file changes before terminating the server
+      watcher.close()
+      server.close()
+      wss.close()
+    }
+
+    const onExitSignal = async () => {
+      await this.deregister('/hc/api/internal/theming/local_preview')
+      close()
+      process.exit(130)
+    }
+
+    process.once('SIGINT', onExitSignal)
+    process.once('SIGTERM', onExitSignal)
+
     return {
       close: () => {
-        // Stop watching file changes before terminating the server
-        watcher.close()
-        server.close()
-        wss.close()
+        process.off('SIGINT', onExitSignal)
+        process.off('SIGTERM', onExitSignal)
+        close()
       }
     }
+  }
+
+  private async previewComponent (componentPath: string, flags: PreviewFlags) {
+    const { logs: tailLogs } = flags
+
+    let component = getComponent(componentPath)
+
+    if (!fs.existsSync(`${componentPath}/dist/index.js`)) {
+      this.error(`Couldn't find a bundle at path: "${componentPath}/dist/index.js" — build the component first`)
+    }
+
+    const { app, server, wss } = this.createServer(flags)
+
+    app.get('/theme_components/:name/:version/index.js', (req, res) => {
+      const bundle = path.resolve(`${componentPath}/dist/index.js`)
+
+      // The version segment is ignored on purpose: the bundle on disk is the
+      // one being developed, whatever version a cached page may still request.
+      if (req.params.name !== component.name || !fs.existsSync(bundle)) {
+        res.sendStatus(404)
+        return
+      }
+
+      const source = fs.readFileSync(bundle, 'utf8')
+      const label = `${component.name}@${component.version}`
+
+      res.header('Content-Type', 'text/javascript')
+      res.header('Cache-Control', 'no-cache')
+      res.send(flags.livereload ? appendLivereloadSnippet(source, getLocalServerBaseUrl(flags, true), label) : source)
+    })
+
+    // Listen before registering so a failed start leaves no registration
+    // pointing at a server that is not ours.
+    await this.listen(server, wss, flags)
+
+    let baseUrl
+    try {
+      baseUrl = await previewComponent(componentPath, flags)
+    } catch (e) {
+      wss.close()
+      server.close()
+      throw e
+    }
+
+    this.log(chalk.bold.green('Ready', chalk.blueBright(`${baseUrl}/hc/admin/local_preview/start`, '🚀')))
+    this.log(`Previewing component ${chalk.bold(`${component.name}@${component.version}`)} — the rendered theme must call {{component '${component.name}'}}`)
+    this.log(`You can exit preview mode in the UI or by visiting ${baseUrl}/hc/admin/local_preview/stop`)
+    tailLogs && this.log(chalk.bold('Tailing logs'))
+
+    const monitoredPaths = [
+      `${componentPath}/component.json`,
+      `${componentPath}/dist`
+    ]
+
+    const handleComponentChange = async (changedPath: string) => {
+      this.log(chalk.bold('Change'), changedPath)
+      if (changedPath === path.join(componentPath, 'component.json')) {
+        try {
+          const next = getComponent(componentPath)
+          await previewComponent(componentPath, flags)
+          component = next
+        } catch (e) {
+          this.error(e as Error, { exit: false })
+          return
+        }
+      }
+      this.broadcastReload(wss)
+    }
+
+    const watcher = chokidar.watch(monitoredPaths, { ignoreInitial: true })
+      .on('add', handleComponentChange)
+      .on('change', handleComponentChange)
+      .on('unlink', handleComponentChange)
+
+    const close = () => {
+      // Stop watching file changes before terminating the server
+      watcher.close()
+      server.close()
+      wss.close()
+    }
+
+    const onExitSignal = async () => {
+      await this.deregister(`/hc/api/internal/theming/local_preview/theme_components/${encodeURIComponent(component.name)}`)
+      close()
+      process.exit(130)
+    }
+
+    process.once('SIGINT', onExitSignal)
+    process.once('SIGTERM', onExitSignal)
+
+    return {
+      close: () => {
+        process.off('SIGINT', onExitSignal)
+        process.off('SIGTERM', onExitSignal)
+        close()
+      }
+    }
+  }
+
+  private createServer (flags: PreviewFlags) {
+    const { logs: tailLogs, 'https-cert': httpsCert, 'https-key': httpsKey } = flags
+
+    let httpsServerOptions: https.ServerOptions | null = null
+
+    if (httpsCert && httpsKey) {
+      httpsServerOptions = {
+        key: fs.readFileSync(httpsKey),
+        cert: fs.readFileSync(httpsCert)
+      }
+    }
+
+    const app = express()
+    const server = httpsServerOptions === null ? http.createServer(app) : https.createServer(httpsServerOptions, app)
+    const wss = new WebSocket.Server({ server, path: '/livereload' })
+
+    app.use(cors())
+    tailLogs && app.use(logMiddleware)
+
+    return { app, server, wss }
+  }
+
+  private async listen (server: http.Server | https.Server, wss: WebSocket.Server, flags: PreviewFlags): Promise<void> {
+    try {
+      // ws forwards server errors as its own 'error' event, which would crash
+      // the process without a listener.
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => reject(error)
+        server.once('error', onError)
+        wss.once('error', onError)
+        server.listen(flags.port, flags.bind, () => {
+          server.removeListener('error', onError)
+          wss.removeListener('error', onError)
+          resolve()
+        })
+      })
+    } catch (e) {
+      if ((e as { code?: string }).code === 'EADDRINUSE') {
+        this.error(`Port ${flags.port} is already in use — another preview session may be running. Pass --port to use a different one`)
+      }
+      throw e
+    }
+  }
+
+  // Best effort: any status (or a dead network) is fine — the session is ending
+  // anyway and the server-side TTL is the backstop.
+  private async deregister (path: string): Promise<void> {
+    try {
+      await request.requestAPI(path, {
+        method: 'delete',
+        headers: {
+          'X-Zendesk-Request-Originator': 'zcli themes:preview'
+        }
+      })
+    } catch { /* best effort */ }
+  }
+
+  private broadcastReload (wss: WebSocket.Server) {
+    wss.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send('reload')
+      }
+    })
   }
 }

--- a/packages/zcli-themes/src/lib/appendLivereloadSnippet.test.ts
+++ b/packages/zcli-themes/src/lib/appendLivereloadSnippet.test.ts
@@ -1,0 +1,52 @@
+import { expect } from '@oclif/test'
+import appendLivereloadSnippet from './appendLivereloadSnippet'
+
+describe('appendLivereloadSnippet', () => {
+  it('appends a single-line livereload snippet', () => {
+    const wrapped = appendLivereloadSnippet('export const mount = () => {};\n', 'ws://localhost:4568', 'request_list@1.0.0')
+
+    const snippet = wrapped.replace('export const mount = () => {};\n', '')
+    expect(snippet.trim().split('\n')).to.have.length(1)
+    expect(snippet).to.contain('new WebSocket("ws://localhost:4568/livereload")')
+    expect(snippet).to.contain('location.reload()')
+    expect(snippet).to.contain('request_list@1.0.0')
+  })
+
+  it('escapes interpolated values as JSON strings', () => {
+    const wrapped = appendLivereloadSnippet('code();\n', 'ws://x', "it's@1.0.0")
+
+    expect(wrapped).to.contain('"[zcli] Previewing it\'s@1.0.0')
+    expect(wrapped).not.to.contain("'it's")
+  })
+
+  it('keeps the original source untouched', () => {
+    const source = 'line1\nline2\n'
+    expect(appendLivereloadSnippet(source, 'ws://x', 'l')).to.match(/^line1\nline2\n/)
+  })
+
+  it('inserts the snippet before a trailing sourceMappingURL comment', () => {
+    const source = 'compiled();\n//# sourceMappingURL=index.js.map'
+    const wrapped = appendLivereloadSnippet(source, 'ws://x', 'l')
+
+    const lines = wrapped.split('\n')
+    expect(lines[lines.length - 1]).to.eq('//# sourceMappingURL=index.js.map')
+    expect(lines[0]).to.eq('compiled();')
+  })
+
+  it('inserts the snippet before a trailing sourceMappingURL comment with trailing newline', () => {
+    const source = 'compiled();\n//# sourceMappingURL=index.js.map\n'
+    const wrapped = appendLivereloadSnippet(source, 'ws://x', 'l')
+
+    const lines = wrapped.split('\n')
+    expect(lines[lines.length - 1]).to.eq('')
+    expect(lines[lines.length - 2]).to.eq('//# sourceMappingURL=index.js.map')
+    expect(lines[0]).to.eq('compiled();')
+  })
+
+  it('treats a sourceMappingURL mention that is not a trailing comment as code', () => {
+    const source = 'const s = "//# sourceMappingURL=not-a-comment";\nmore();\n'
+    const wrapped = appendLivereloadSnippet(source, 'ws://x', 'l')
+
+    expect(wrapped.startsWith(source)).to.eq(true)
+  })
+})

--- a/packages/zcli-themes/src/lib/appendLivereloadSnippet.ts
+++ b/packages/zcli-themes/src/lib/appendLivereloadSnippet.ts
@@ -1,0 +1,18 @@
+// The snippet is appended (never prepended) and kept to a single line so the
+// bundle's sourcemap line mappings stay intact, and it must stay free of
+// imports/exports so the bundle keeps working as a plain ES module.
+export default function appendLivereloadSnippet (source: string, wsBaseUrl: string, label: string): string {
+  const snippet = `;(() => { const s = new WebSocket(${JSON.stringify(`${wsBaseUrl}/livereload`)}); s.onopen = () => console.log(${JSON.stringify(`[zcli] Previewing ${label} — reloading on change`)}); s.onmessage = e => e.data === 'reload' && location.reload(); })();\n`
+
+  const marker = '//# sourceMappingURL='
+  const markerIndex = source.lastIndexOf(marker)
+  const markerOnOwnLastLine = markerIndex !== -1 &&
+    (markerIndex === 0 || source[markerIndex - 1] === '\n') &&
+    !source.slice(markerIndex).trimEnd().includes('\n')
+
+  if (markerOnOwnLastLine) {
+    return source.slice(0, markerIndex) + snippet + source.slice(markerIndex)
+  }
+
+  return (source.endsWith('\n') ? source : `${source}\n`) + snippet
+}

--- a/packages/zcli-themes/src/lib/getComponent.test.ts
+++ b/packages/zcli-themes/src/lib/getComponent.test.ts
@@ -1,0 +1,78 @@
+import * as sinon from 'sinon'
+import * as fs from 'fs'
+import { expect } from '@oclif/test'
+import getComponent from './getComponent'
+
+describe('getComponent', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('returns the component.json file parsed as json', () => {
+    const existsSyncStub = sinon.stub(fs, 'existsSync')
+    const readFileSyncStub = sinon.stub(fs, 'readFileSync')
+
+    const component = {
+      name: 'request_list',
+      version: '1.0.0',
+      settings: [],
+      data_requirements: { locale: { source: 'help_center.base_locale' } }
+    }
+
+    existsSyncStub
+      .withArgs('component/path/component.json')
+      .returns(true)
+
+    readFileSyncStub
+      .withArgs('component/path/component.json')
+      .returns(JSON.stringify(component))
+
+    expect(getComponent('component/path')).to.deep.equal(component)
+  })
+
+  it('throws an error when it can\'t find a component.json file', () => {
+    const existsSyncStub = sinon.stub(fs, 'existsSync')
+
+    existsSyncStub
+      .withArgs('component/path/component.json')
+      .returns(false)
+
+    expect(() => {
+      getComponent('component/path')
+    }).to.throw('Couldn\'t find a component.json file at path: "component/path/component.json"')
+  })
+
+  it('throws an error when the component.json file is malformed', () => {
+    const existsSyncStub = sinon.stub(fs, 'existsSync')
+    const readFileSyncStub = sinon.stub(fs, 'readFileSync')
+
+    existsSyncStub
+      .withArgs('component/path/component.json')
+      .returns(true)
+
+    readFileSyncStub
+      .withArgs('component/path/component.json')
+      .returns('{"name": "request_list",,, }')
+
+    expect(() => {
+      getComponent('component/path')
+    }).to.throw('component.json file was malformed at path: "component/path/component.json"')
+  })
+
+  it('throws an error when name or version are missing', () => {
+    const existsSyncStub = sinon.stub(fs, 'existsSync')
+    const readFileSyncStub = sinon.stub(fs, 'readFileSync')
+
+    existsSyncStub
+      .withArgs('component/path/component.json')
+      .returns(true)
+
+    readFileSyncStub
+      .withArgs('component/path/component.json')
+      .returns(JSON.stringify({ name: 'request_list' }))
+
+    expect(() => {
+      getComponent('component/path')
+    }).to.throw('must declare a "name" and a "version"')
+  })
+})

--- a/packages/zcli-themes/src/lib/getComponent.ts
+++ b/packages/zcli-themes/src/lib/getComponent.ts
@@ -1,0 +1,25 @@
+import type { Component } from '../types'
+import { CLIError } from '@oclif/core/lib/errors'
+import * as fs from 'fs'
+import * as chalk from 'chalk'
+
+export default function getComponent (componentPath: string): Component {
+  const componentFilePath = `${componentPath}/component.json`
+
+  if (!fs.existsSync(componentFilePath)) {
+    throw new CLIError(chalk.red(`Couldn't find a component.json file at path: "${componentFilePath}"`))
+  }
+
+  let component: Component
+  try {
+    component = JSON.parse(fs.readFileSync(componentFilePath, 'utf8'))
+  } catch (error) {
+    throw new CLIError(chalk.red(`component.json file was malformed at path: "${componentFilePath}"`))
+  }
+
+  if (!component.name || !component.version) {
+    throw new CLIError(chalk.red(`component.json at path: "${componentFilePath}" must declare a "name" and a "version"`))
+  }
+
+  return component
+}

--- a/packages/zcli-themes/src/lib/previewComponent.test.ts
+++ b/packages/zcli-themes/src/lib/previewComponent.test.ts
@@ -1,0 +1,107 @@
+import * as sinon from 'sinon'
+import * as axios from 'axios'
+import { expect } from '@oclif/test'
+import * as getComponent from './getComponent'
+import { request } from '@zendesk/zcli-core'
+import * as errors from '@oclif/core/lib/errors'
+import previewComponent from './previewComponent'
+
+const component = {
+  name: 'request_list',
+  version: '1.0.0',
+  settings: [{ label: 'group', variables: [{ identifier: 'heading_text', type: 'text', value: 'Request list' }] }],
+  data_requirements: { locale: { source: 'help_center.base_locale' } }
+}
+
+const flags = {
+  bind: 'localhost',
+  port: 1000,
+  logs: true,
+  livereload: true
+}
+
+describe('previewComponent', () => {
+  beforeEach(() => {
+    sinon.restore()
+  })
+
+  it('registers the component with the local_preview theme_components endpoint and returns the used baseURL', async () => {
+    const getComponentStub = sinon.stub(getComponent, 'default')
+    const requestStub = sinon.stub(request, 'requestAPI')
+
+    getComponentStub.withArgs('component/path').returns(component)
+
+    requestStub.returns(Promise.resolve({
+      status: 200,
+      statusText: 'OK',
+      config: { baseURL: 'https://z3ntest.zendesk.com' }
+    }) as axios.AxiosPromise)
+
+    const baseUrl = await previewComponent('component/path', flags)
+
+    expect(requestStub.calledWith('/hc/api/internal/theming/local_preview/theme_components', sinon.match({
+      method: 'put',
+      headers: {
+        'X-Zendesk-Request-Originator': 'zcli themes:preview'
+      },
+      data: {
+        theme_components: {
+          request_list: {
+            version: '1.0.0',
+            src: 'http://localhost:1000/theme_components/request_list/1.0.0/index.js',
+            settings: component.settings,
+            data_requirements: component.data_requirements
+          }
+        }
+      }
+    }))).to.equal(true)
+
+    expect(baseUrl).to.equal('https://z3ntest.zendesk.com')
+  })
+
+  it('defaults missing settings and data_requirements', async () => {
+    const getComponentStub = sinon.stub(getComponent, 'default')
+    const requestStub = sinon.stub(request, 'requestAPI')
+
+    getComponentStub.withArgs('component/path').returns({ name: 'request_list', version: '1.0.0' })
+    requestStub.returns(Promise.resolve({ status: 200, config: {} }) as axios.AxiosPromise)
+
+    await previewComponent('component/path', flags)
+
+    const data = requestStub.firstCall.args[1].data
+    expect(data.theme_components.request_list.settings).to.deep.eq([])
+    expect(data.theme_components.request_list.data_requirements).to.deep.eq({})
+  })
+
+  it('surfaces the general_error returned by the endpoint', async () => {
+    const getComponentStub = sinon.stub(getComponent, 'default')
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const errorStub = sinon.stub(errors, 'error').callThrough()
+
+    getComponentStub.withArgs('component/path').returns(component)
+    requestStub.throws({ response: { status: 422, data: { general_error: 'Theme components are not enabled for this account' } } })
+
+    try {
+      await previewComponent('component/path', flags)
+    } catch { /* expected */ }
+
+    expect(errorStub.calledOnce).to.eq(true)
+    expect(errorStub.firstCall.args[0]).to.eq('Theme components are not enabled for this account')
+  })
+
+  it('reports a missing endpoint as unsupported account', async () => {
+    const getComponentStub = sinon.stub(getComponent, 'default')
+    const requestStub = sinon.stub(request, 'requestAPI')
+    const errorStub = sinon.stub(errors, 'error').callThrough()
+
+    getComponentStub.withArgs('component/path').returns(component)
+    requestStub.throws({ response: { status: 404, data: {} } })
+
+    try {
+      await previewComponent('component/path', flags)
+    } catch { /* expected */ }
+
+    expect(errorStub.calledOnce).to.eq(true)
+    expect(errorStub.firstCall.args[0]).to.contain('not supported')
+  })
+})

--- a/packages/zcli-themes/src/lib/previewComponent.ts
+++ b/packages/zcli-themes/src/lib/previewComponent.ts
@@ -1,0 +1,48 @@
+import type { Flags } from '../types'
+import getComponent from './getComponent'
+import * as chalk from 'chalk'
+import { request } from '@zendesk/zcli-core'
+import { error } from '@oclif/core/lib/errors'
+import { CliUx } from '@oclif/core'
+import { getLocalServerBaseUrl } from './getLocalServerBaseUrl'
+import type { AxiosError } from 'axios'
+
+export default async function previewComponent (componentPath: string, flags: Flags): Promise<string | void> {
+  const component = getComponent(componentPath)
+
+  const src = `${getLocalServerBaseUrl(flags)}/theme_components/${component.name}/${component.version}/index.js`
+
+  try {
+    CliUx.ux.action.start('Registering component')
+    const { config: { baseURL } } = await request.requestAPI('/hc/api/internal/theming/local_preview/theme_components', {
+      method: 'put',
+      headers: {
+        'X-Zendesk-Request-Originator': 'zcli themes:preview'
+      },
+      data: {
+        theme_components: {
+          [component.name]: {
+            version: component.version,
+            src,
+            settings: component.settings || [],
+            data_requirements: component.data_requirements || {}
+          }
+        }
+      },
+      validateStatus: (status: number) => status === 200
+    })
+    CliUx.ux.action.stop('Ok')
+    return baseURL
+  } catch (e) {
+    CliUx.ux.action.stop(chalk.bold.red('!'))
+    const { response, message } = e as AxiosError
+    if (response) {
+      const { general_error: generalError } = response.data as { general_error: string }
+      if (generalError) error(generalError)
+      else if (response.status === 404) error('Component preview is not supported by this Zendesk account: the help_center theme_components endpoint is missing')
+      else error(message)
+    } else {
+      error(e as AxiosError)
+    }
+  }
+}

--- a/packages/zcli-themes/src/types.ts
+++ b/packages/zcli-themes/src/types.ts
@@ -23,6 +23,13 @@ export type Manifest = {
   settings: Setting[]
 }
 
+export type Component = {
+  name: string,
+  version: string,
+  settings?: Setting[],
+  data_requirements?: Record<string, { source: string }>
+}
+
 export type ValidationError = {
   description: string,
   line?: number,

--- a/packages/zcli-themes/tests/functional/mocks/base_component/component.json
+++ b/packages/zcli-themes/tests/functional/mocks/base_component/component.json
@@ -1,0 +1,15 @@
+{
+  "name": "request_list",
+  "version": "1.0.0",
+  "settings": [
+    {
+      "label": "request_list_group_label",
+      "variables": [
+        { "identifier": "heading_text", "type": "text", "value": "Request list" }
+      ]
+    }
+  ],
+  "data_requirements": {
+    "locale": { "source": "help_center.base_locale" }
+  }
+}

--- a/packages/zcli-themes/tests/functional/preview.test.ts
+++ b/packages/zcli-themes/tests/functional/preview.test.ts
@@ -3,7 +3,8 @@ import { expect, test } from '@oclif/test'
 import * as sinon from 'sinon'
 import * as path from 'path'
 import * as fs from 'fs'
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
+import * as http from 'http'
 import { cloneDeep } from 'lodash'
 import PreviewCommand from '../../src/commands/themes/preview'
 import env from './env'
@@ -79,6 +80,220 @@ describe('themes:preview', function () {
         expect((await axios.get('http://0.0.0.0:9999/guide/style.css')).data).to.contain('color: #000000;')
         // Restore manifest.json
         fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+      })
+  })
+
+  describe('component preview', function () {
+    const baseComponentPath = path.join(__dirname, 'mocks/base_component')
+    const bundlePath = path.join(baseComponentPath, 'dist/index.js')
+    const bundle = 'export function mount (container, props) {\n  container.textContent = props.settings.heading_text\n}\n'
+
+    // dist/ is gitignored build output, so the fixture writes its own bundle
+    before(() => {
+      fs.mkdirSync(path.dirname(bundlePath), { recursive: true })
+      fs.writeFileSync(bundlePath, bundle)
+    })
+
+    describe('with live-reload', () => {
+      let server: { close: () => void }
+
+      const preview = test
+        .stdout()
+        .env(env)
+        .do(() => {
+          fetchStub.withArgs(sinon.match({
+            url: 'https://z3ntest.zendesk.com/hc/api/internal/theming/local_preview/theme_components',
+            method: 'PUT'
+          })).resolves({
+            status: 200,
+            ok: true,
+            text: () => Promise.resolve('')
+          })
+        })
+        .do(async () => {
+          server = await PreviewCommand.run([baseComponentPath, '--bind', '0.0.0.0', '--port', '9998'])
+        })
+
+      afterEach(() => {
+        server.close()
+      })
+
+      preview
+        .it('should register the component and print instructions', async (ctx) => {
+          // the stubbed fetch only resolves for PUTs to the theme_components endpoint
+          expect(fetchStub.calledWith(sinon.match({
+            url: 'https://z3ntest.zendesk.com/hc/api/internal/theming/local_preview/theme_components',
+            method: 'PUT'
+          }))).to.eq(true)
+          expect(ctx.stdout).to.contain('Ready https://z3ntest.zendesk.com/hc/admin/local_preview/start 🚀')
+          expect(ctx.stdout).to.contain('Previewing component request_list@1.0.0')
+        })
+
+      preview
+        .it('should serve the bundle with the livereload snippet appended', async () => {
+          const response = await axios.get('http://0.0.0.0:9998/theme_components/request_list/1.0.0/index.js')
+
+          expect(response.status).to.eq(200)
+          expect(response.headers['cache-control']).to.contain('no-cache')
+          expect(response.data).to.contain('export function mount')
+          expect(response.data).to.contain('new WebSocket("ws://0.0.0.0:9998/livereload")')
+        })
+
+      preview
+        .it('should serve the bundle under any version path', async () => {
+          expect((await axios.get('http://0.0.0.0:9998/theme_components/request_list/9.9.9/index.js')).status).to.eq(200)
+        })
+
+      preview
+        .it('should not serve other components', async () => {
+          try {
+            await axios.get('http://0.0.0.0:9998/theme_components/other/1.0.0/index.js')
+            throw new Error('expected a 404')
+          } catch (e) {
+            expect((e as AxiosError).response?.status).to.eq(404)
+          }
+        })
+    })
+
+    describe('with --no-livereload', () => {
+      let server: { close: () => void }
+
+      const preview = test
+        .stdout()
+        .env(env)
+        .do(() => {
+          fetchStub.withArgs(sinon.match({
+            url: 'https://z3ntest.zendesk.com/hc/api/internal/theming/local_preview/theme_components',
+            method: 'PUT'
+          })).resolves({
+            status: 200,
+            ok: true,
+            text: () => Promise.resolve('')
+          })
+        })
+        .do(async () => {
+          server = await PreviewCommand.run([baseComponentPath, '--bind', '0.0.0.0', '--port', '9998', '--no-livereload'])
+        })
+
+      afterEach(() => {
+        server.close()
+      })
+
+      preview
+        .it('should serve the bundle verbatim', async () => {
+          const response = await axios.get('http://0.0.0.0:9998/theme_components/request_list/1.0.0/index.js')
+
+          expect(response.status).to.eq(200)
+          expect(response.data).to.eq(bundle)
+        })
+    })
+  })
+
+  describe('when the directory does not exist', () => {
+    test
+      .stdout()
+      .env(env)
+      .it('reports a clear error', async () => {
+        try {
+          await PreviewCommand.run(['./no-such-directory'])
+        } catch (e) {
+          expect((e as Error).message).to.contain('Couldn\'t find a directory at path:')
+          expect(fetchStub.called).to.eq(false)
+          return
+        }
+        throw new Error('expected the command to fail')
+      })
+  })
+
+  describe('when component registration fails after listening', () => {
+    const baseComponentPath = path.join(__dirname, 'mocks/base_component')
+    const bundlePath = path.join(baseComponentPath, 'dist/index.js')
+
+    before(() => {
+      fs.mkdirSync(path.dirname(bundlePath), { recursive: true })
+      fs.writeFileSync(bundlePath, 'export function mount () {}\n')
+    })
+
+    test
+      .stdout()
+      .env(env)
+      .do(() => {
+        fetchStub.withArgs(sinon.match({
+          url: 'https://z3ntest.zendesk.com/hc/api/internal/theming/local_preview/theme_components',
+          method: 'PUT'
+        })).resolves({
+          status: 500,
+          ok: false,
+          text: () => Promise.resolve('Internal Server Error')
+        })
+      })
+      .it('closes the server so the port stays free', async () => {
+        try {
+          await PreviewCommand.run([baseComponentPath, '--bind', '0.0.0.0', '--port', '9995'])
+        } catch { /* expected */ }
+
+        const probe = http.createServer()
+        await new Promise<void>((resolve, reject) => {
+          probe.once('error', reject)
+          probe.listen(9995, '0.0.0.0', resolve)
+        })
+        probe.close()
+      })
+  })
+
+  describe('when the component bundle has not been built', () => {
+    const baseComponentPath = path.join(__dirname, 'mocks/base_component')
+    const bundlePath = path.join(baseComponentPath, 'dist/index.js')
+
+    afterEach(() => {
+      fs.mkdirSync(path.dirname(bundlePath), { recursive: true })
+      fs.writeFileSync(bundlePath, 'export function mount () {}\n')
+    })
+
+    test
+      .stdout()
+      .env(env)
+      .it('fails before registering or listening', async () => {
+        fs.rmSync(path.dirname(bundlePath), { recursive: true, force: true })
+
+        try {
+          await PreviewCommand.run([baseComponentPath, '--bind', '0.0.0.0', '--port', '9996'])
+        } catch (e) {
+          expect((e as Error).message).to.contain('dist/index.js')
+          expect((e as Error).message).to.contain('build the component first')
+          expect(fetchStub.called).to.eq(false)
+          return
+        }
+        throw new Error('expected the command to fail')
+      })
+  })
+
+  describe('when the port is already in use', () => {
+    const baseComponentPath = path.join(__dirname, 'mocks/base_component')
+    let blocker: http.Server
+
+    before(async () => {
+      blocker = http.createServer()
+      await new Promise<void>((resolve) => blocker.listen(9997, '0.0.0.0', resolve))
+    })
+
+    after(() => {
+      blocker.close()
+    })
+
+    test
+      .stdout()
+      .env(env)
+      .it('reports a friendly error and does not register the component', async () => {
+        try {
+          await PreviewCommand.run([baseComponentPath, '--bind', '0.0.0.0', '--port', '9997'])
+        } catch (e) {
+          expect((e as Error).message).to.contain('Port 9997 is already in use')
+          expect((e as Error).message).to.contain('Pass --port to use a different one')
+          expect(fetchStub.called).to.eq(false)
+          return
+        }
+        throw new Error('expected the command to fail')
       })
   })
 


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat(buttons):
     add a muted button component". the title informs the semantic
     version bump if this PR is merged. -->

## Description

Client half of the theme component local preview loop (server: zendesk/help_center#34599). Component authors get the same preview workflow theme developers already know: running `zcli themes:preview` in a component directory (detected via `component.json`) registers the component with the user's help_center preview session and serves the local `dist/index.js` bundle, so `{{component}}` placements render the local build with live-reload on rebuild. The theme preview flow is unchanged.

References:

- https://zendesk.atlassian.net/browse/GG-5239
- help_center: https://github.com/zendesk/help_center/pull/34599
- help-center-components: https://github.com/zendesk/help-center-components/pull/4


<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`226f494`](https://github.com/zendesk/zcli/pull/408/commits/226f494ac3ed15445cc106f7b3357df4b91438c0) feat(themes): preview theme components with themes:preview

A directory with a component.json now starts a component preview session:
zcli registers the component with the caller's help_center preview session
and serves its dist/index.js bundle from the local server, so {{component}}
placements render the author's local build. A directory with a manifest.json
keeps the existing theme preview behavior; a directory with both, a missing
directory, or an occupied port each fail with a clear error.

The bundle is served under /theme_components/<name>/<version>/index.js,
mirroring the platform convention; the version segment is ignored and the
build on disk is served. With live-reload enabled a single-line WebSocket
snippet is appended (placed before a trailing sourceMappingURL comment so
sourcemaps stay intact); --no-livereload serves the bundle byte-for-byte.
component.json changes re-register and reload the page; dist/ changes just
reload.

Ctrl+C deregisters the session's own scope server-side (best effort; the
redis TTL remains the backstop).


<!-- === GH HISTORY FENCE === -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

- [ ] :guardsman: includes new unit and functional tests
